### PR TITLE
Fix missing get_info in system_wrapper_loop

### DIFF
--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -1738,7 +1738,9 @@ system_wrapper_loop(Name, Wrapped, Info) ->
             Type:Reason ->
               Stacktrace = erlang:get_stacktrace(),
               ?crash({system_wrapper_error, Name, Type, Reason, Stacktrace})
-          end
+          end;
+        {get_info, To} ->
+          To ! {info, Info}
       end
   end,
   system_wrapper_loop(Name, Wrapped, Info).

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -1740,7 +1740,8 @@ system_wrapper_loop(Name, Wrapped, Info) ->
               ?crash({system_wrapper_error, Name, Type, Reason, Stacktrace})
           end;
         {get_info, To} ->
-          To ! {info, Info}
+          To ! {info, Info},
+          ok
       end
   end,
   system_wrapper_loop(Name, Wrapped, Info).


### PR DESCRIPTION
The missing clause caused a case_clause exit:

    =ERROR REPORT==== 10-Mar-2015::10:33:54 ===
    Error in process <0.62.0> with exit value: {{case_clause,{get_info,<0.127.0>}},[{concuerror_callback,system_wrapper_loop,3,[{file,"src/concuerror_callback.erl"},{line,1684}]}]}
    Error: Reason: {{case_clause,{get_info,<0.127.0>}},
             [{concuerror_callback,system_wrapper_loop,3,
                                   [{file,"src/concuerror_callback.erl"},
                                    {line,1684}]}]}
    Trace: [{concuerror_options,compile_and_load,2,
                                [{file,"src/concuerror_options.erl"},{line,318}]},
            {concuerror_options,finalize,1,
                                [{file,"src/concuerror_options.erl"},{line,166}]},
            {concuerror,run,1,[{file,"src/concuerror.erl"},{line,22}]},
            {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,657}]},
            {erl_eval,expr,5,[{file,"erl_eval.erl"},{line,441}]},
            {escript,eval_exprs,5,[{file,"escript.erl"},{line,865}]},
            {erl_eval,local_func,5,[{file,"erl_eval.erl"},{line,544}]},
            {escript,interpret,4,[{file,"escript.erl"},{line,781}]}]
