### PR TITLE
Emit an error message if process_info is asked for a system process

### DIFF
--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -1738,7 +1738,9 @@ system_wrapper_loop(Name, Wrapped, Info) ->
             Type:Reason ->
               Stacktrace = erlang:get_stacktrace(),
               ?crash({system_wrapper_error, Name, Type, Reason, Stacktrace})
-          end
+          end;
+        {get_info, _} ->
+          ?crash({wrapper_asked_for_status, Name})
       end
   end,
   system_wrapper_loop(Name, Wrapped, Info).
@@ -1975,7 +1977,15 @@ explain_error({unsupported_request, Name, Type}) ->
     "A process send a request of type '~p' to ~p. Concuerror does not yet support"
     " this type of request to this process.~n"
     ?notify_us_msg,
-    [Type, Name]).
+    [Type, Name]);
+explain_error({wrapper_asked_for_status, Name}) ->
+  io_lib:format(
+    "A process attempted to request process_info for a system process (~p)."
+    " Concuerror cannot track and restore the state of system processes, so"
+    " this information may change between interleavings, leading to errors in"
+    " the exploration. It should be possible to refactor your test to avoid"
+    " this problem.",
+    [Name]).
 
 location(F, L) ->
   Basename = filename:basename(F),

--- a/tests/suites/basic_tests/results/inspect_system-test-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/inspect_system-test-inf-dpor.txt
@@ -1,0 +1,41 @@
+################################################################################
+Concuerror started with options:
+  [{after_timeout,infinity},
+   {assume_racing,false},
+   {delay_bound,infinity},
+   {depth_bound,5000},
+   {entry_point,{inspect_system,test,[]}},
+   {files,["/home/stavros/git/Concuerror/tests/suites/basic_tests/src/inspect_system.erl"]},
+   {ignore_error,[]},
+   {ignore_first_crash,true},
+   {instant_delivery,false},
+   {interleaving_bound,infinity},
+   {non_racing_system,[]},
+   {optimal,true},
+   {print_depth,20},
+   {scheduling,round_robin},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,infinity},
+   {treat_as_normal,[]}]
+################################################################################
+Erroneous interleaving 1:
+* Concuerror crashed
+--------------------------------------------------------------------------------
+Interleaving info:
+   1: P: kernel_sup = erlang:whereis(kernel_sup)
+    in inspect_system.erl line 10
+################################################################################
+Errors:
+--------------------------------------------------------------------------------
+A process attempted to request process_info for a system process (kernel_sup). Concuerror cannot track and restore the state of system processes, so this information may change between interleavings, leading to errors in the exploration. It should be possible to refactor your test to avoid this problem.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+Instrumented inspect_system
+Instrumented io_lib
+################################################################################
+Done! (Exit status: error)
+  Summary: 1 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/src/inspect_system.erl
+++ b/tests/suites/basic_tests/src/inspect_system.erl
@@ -1,0 +1,10 @@
+-module(inspect_system).
+
+-export([scenarios/0]).
+-export([test/0]).
+
+scenarios() ->
+    [{test, inf, dpor, crash}].
+
+test() ->
+  {group_leader, GL} = process_info(whereis(kernel_sup), group_leader).


### PR DESCRIPTION
This patches the ugly crash reported in #48. Thanks to evnu for the report!