### PR TITLE
Fix the Makefile for dialyzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ deps/%/.git:
 
 PLT=.$(NAME)_plt
 
-DIALYZER_APPS = erts kernel stdlib compiler crypto
+DIALYZER_APPS = erts kernel stdlib compiler crypto tools
 DIALYZER_FLAGS = -Wunmatched_returns -Wunderspecs
 
 .PHONY: dialyze
@@ -167,7 +167,7 @@ clean:
 	$(RM) -r ebin
 
 .PHONY: distclean
-distclean: clean
+distclean: clean dialyzer-clean
 	$(RM) $(GENERATED_HRLS)
 	$(RM) -r deps/*
 	git checkout -- deps


### PR DESCRIPTION
 - add 'tools' application to the PLT (so that cover functions are known)
 - 'make distclean' should also remove the PLT