### PR TITLE
Assorted improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - untested code for 'hijacking' processes (e.g. application_controller (#2))
 
 ### Changed
+- symbolic PIDs are now shown as "<symbol/last registered name>"
 - report shows mailbox contents when a deadlock is detected
 - significantly optimized DPOR implementations
 - moved concuerror executable to /bin directory

--- a/src/concuerror.hrl
+++ b/src/concuerror.hrl
@@ -145,29 +145,30 @@
 
 -define(process_name_none, 0).
 -define(new_process(Pid, Symbolic),
-        {Pid, exited, ?process_name_none, undefined, Symbolic, 0, regular}).
+        {Pid, exited, ?process_name_none, ?process_name_none, undefined, Symbolic, 0, regular}).
 -define(new_system_process(Pid, Name, Type),
-        {Pid, running, Name, undefined, atom_to_list(Name), 0, Type}).
--define(process_pat_pid(Pid),                {Pid,      _,    _, _, _, _,    _}).
--define(process_pat_pid_name(Pid, Name),     {Pid,      _, Name, _, _, _,    _}).
--define(process_pat_pid_status(Pid, Status), {Pid, Status,    _, _, _, _,    _}).
--define(process_pat_pid_kind(Pid, Kind),     {Pid,      _,    _, _, _, _, Kind}).
+        {Pid, running, Name, Name, undefined, atom_to_list(Name), 0, Type}).
+-define(process_pat_pid(Pid),                {Pid,      _,    _, _, _, _, _,    _}).
+-define(process_pat_pid_name(Pid, Name),     {Pid,      _, Name, _, _, _, _,    _}).
+-define(process_pat_pid_status(Pid, Status), {Pid, Status,    _, _, _, _, _,    _}).
+-define(process_pat_pid_kind(Pid, Kind),     {Pid,      _,    _, _, _, _, _, Kind}).
 -define(process_status, 2).
 -define(process_name, 3).
--define(process_leader, 4).
--define(process_symbolic, 5).
--define(process_children, 6).
--define(process_kind, 7).
+-define(process_last_name, 4).
+-define(process_leader, 5).
+-define(process_symbolic, 6).
+-define(process_children, 7).
+-define(process_kind, 8).
 -define(process_match_name_to_pid(Name),
-        {'$1',   '_', Name, '_', '_', '_', '_'}).
+        {'$1',   '_', Name, '_', '_', '_', '_', '_'}).
 -define(process_match_symbol_to_pid(Symbol),
-        {'$1',   '_', '_', '_', Symbol, '_', '_'}).
+        {'$1',   '_', '_', '_', '_', Symbol, '_', '_'}).
 
 -define(active_processes(P),
         lists:sort(
           ets:select(
             P,
-            [{{'$1', '$2', '_', '_', '_', '_', '_'},
+            [{{'$1', '$2', '_', '_', '_', '_', '_', '_'},
               [{'=/=', '$2', exited}],
               ['$1']}]))).
 %%------------------------------------------------------------------------------

--- a/src/concuerror.hrl
+++ b/src/concuerror.hrl
@@ -147,7 +147,7 @@
 -define(new_process(Pid, Symbolic),
         {Pid, exited, ?process_name_none, ?process_name_none, undefined, Symbolic, 0, regular}).
 -define(new_system_process(Pid, Name, Type),
-        {Pid, running, Name, Name, undefined, atom_to_list(Name), 0, Type}).
+        {Pid, running, Name, Name, undefined, "P." ++ atom_to_list(Name), 0, Type}).
 -define(process_pat_pid(Pid),                {Pid,      _,    _, _, _, _, _,    _}).
 -define(process_pat_pid_name(Pid, Name),     {Pid,      _, Name, _, _, _, _,    _}).
 -define(process_pat_pid_status(Pid, Status), {Pid, Status,    _, _, _, _, _,    _}).

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -831,7 +831,7 @@ run_built_in(erlang, send, 3, [Recipient, Message, _Options], Info) ->
           case Recipient of
             A when is_atom(A) -> Recipient;
             {A, N} when is_atom(A), N =:= node() -> A
-          end,            
+          end,
         {P, Info} = run_built_in(erlang, whereis, 1, [T], Info),
         P
     end,
@@ -1747,7 +1747,7 @@ ets_ops_access_rights_map(Op) ->
     {next          ,_} -> read;
     {select        ,_} -> read;
     {select_delete ,_} -> write;
-    {update_counter,3} -> write                            
+    {update_counter,3} -> write
   end.
 
 %%------------------------------------------------------------------------------
@@ -2081,7 +2081,7 @@ explain_error({not_local_node, Node}) ->
     " remote nodes yet.",
     [Node]);
 explain_error({process_did_not_respond, Timeout, Actor}) ->
-  io_lib:format( 
+  io_lib:format(
     "A process (~p) took more than ~pms to report a built-in event. You can try"
     " to increase the '--timeout' limit and/or ensure that there are no"
     " infinite loops in your test.",

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -529,6 +529,18 @@ run_built_in(erlang, monitor, 2, [Type, InTarget], Info) ->
         end
     end,
   {Ref, FinalInfo};
+run_built_in(erlang, process_info, 2, [Pid, Items], Info) when is_list(Items) ->
+  ItemFun =
+    fun (Item) ->
+        ?badarg_if_not(is_atom(Item)),
+        {ItemRes, _} = run_built_in(erlang, process_info, 2, [Pid, Item], Info),
+        if Item =:= registered_name, ItemRes =:= [] ->
+            {registered_name, []};
+           is_tuple(ItemRes) ->
+            ItemRes
+        end
+    end,
+  {lists:map(ItemFun, Items), Info};
 run_built_in(erlang, process_info, 2, [Pid, Item], Info) when is_atom(Item) ->
   {Alive, _} = run_built_in(erlang, is_process_alive, 1, [Pid], Info),
   case Alive of

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -818,10 +818,11 @@ run_built_in(erlang, spawn_opt, 1, [{Module, Name, Args, SpawnOpts}], Info) ->
   Pid ! {start, Module, Name, Args},
   ok = wait_process(Pid, Timeout),
   {Result, FinalInfo};
+run_built_in(erlang, send, 3, [Recipient, Message, _Options], Info) ->
+  {_, FinalInfo} = run_built_in(erlang, send, 2, [Recipient, Message], Info),
+  {ok, FinalInfo};
 run_built_in(erlang, Send, 2, [Recipient, Message], Info)
   when Send =:= '!'; Send =:= 'send' ->
-  run_built_in(erlang, send, 3, [Recipient, Message, []], Info);
-run_built_in(erlang, send, 3, [Recipient, Message, _Options], Info) ->
   #concuerror_info{event = #event{event_info = EventInfo}} = Info,
   Pid =
     case is_pid(Recipient) of

--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -350,6 +350,15 @@ dependent_exit(_Exit, {ets, _, _}) ->
 
 %%------------------------------------------------------------------------------
 
+dependent_process_info(#builtin_event{mfargs = {M,F,[Pid, List]}} = ProcessInfo,
+                       Other)
+  when is_list(List) ->
+  Pred =
+    fun(Item) ->
+        ItemInfo = ProcessInfo#builtin_event{mfargs = {M,F,[Pid,Item]}},
+        dependent_process_info(ItemInfo, Other)
+    end,
+  lists:any(Pred, List);
 dependent_process_info(#builtin_event{mfargs = {_,_,[Pid, group_leader]}},
                        Other) ->
   case Other of

--- a/src/concuerror_logger.erl
+++ b/src/concuerror_logger.erl
@@ -744,5 +744,13 @@ print_depth_tip() ->
 setup_symbolic_names(SymbolicNames, Processes) ->
   case SymbolicNames of
     false -> ok;
-    true -> concuerror_callback:setup_logger(Processes)
+    true ->
+      print_symbolic_info(),
+      concuerror_callback:setup_logger(Processes)
   end.
+
+print_symbolic_info() ->
+  Tip =
+    "Showing PIDs as \"<symbolic name(/last registered name)>\""
+    " ('-h symbolic_names').~n",
+  ?unique(self(), ?linfo, Tip, []).

--- a/src/concuerror_options.erl
+++ b/src/concuerror_options.erl
@@ -95,9 +95,15 @@ options() ->
     "The DOT graph can be converted to an image with 'dot -Tsvg -o graph.svg"
     " <graph>"}
   ,{symbolic_names, [output, visual, erlang], $s, {boolean, true},
-    "Use symbolic PIDs in graph/log",
-    "Use symbolic names for process identifiers in the output report (and"
-    " graph)."}
+    "Use symbolic process names",
+    "Replace PIDs with symbolic names in outputs. The format used is:~n"
+    "  \"<[symbolic name]/[last registered name]>\"~n"
+    "where [symbolic name] is:~n"
+    " * \"P\", for the first process and~n"
+    " * \"[parent's symbolic name].[ordinal]\", for any other process,"
+    " where [ordinal] shows the order of spawning (e.g. \"<P.2>\" is the"
+    " second process spawned by \"<P>\").~n"
+    "The [last registered name] part is shown only if relevant."}
   ,{print_depth, [output, visual], undefined, {integer, ?DEFAULT_PRINT_DEPTH},
     "Print depth for log/graph",
     "Specifies the max depth for any terms printed in the log (behaves just as"

--- a/tests-real/suites/options/option3-tests
+++ b/tests-real/suites/options/option3-tests
@@ -4,6 +4,14 @@
 
 print_blue "$0"
 
+testing "Symbolic registered names Info"
+! concuerror_console -f src/register.erl
+consolehas "Showing PIDs as \"<symbolic name(/last registered name)>\" ('-h symbolic_names')."
+
+testing "Symbolic registered names error info"
+! concuerror_console -f src/register.erl
+outputhas "process <P.1/foo> exited abnormally"
+
 testing "No warnings for multiple -pa"
 concuerror_console -vvvv -f src/foo.erl -pa .. src
 print_ok

--- a/tests-real/suites/options/src/register.erl
+++ b/tests-real/suites/options/src/register.erl
@@ -1,0 +1,11 @@
+-module(register).
+
+-export([test/0]).
+
+-concuerror_options_forced([symbolic_names]).
+
+test() ->
+  spawn(fun() ->
+            register(foo, self()),
+            exit(abnormal)
+        end).

--- a/tests-real/suites/poolboy/test
+++ b/tests-real/suites/poolboy/test
@@ -54,7 +54,7 @@ has Warning
 has Tip
 
 testing "Abnormal exit found"
-mygrep "\* At step .* process P\.1 exited abnormally"
+mygrep "\* At step .* process <P\.1/poolboy_test> exited abnormally"
 good
 
 testing "Rerun"
@@ -69,7 +69,7 @@ mygrep "Stop testing on first error."
 good
 
 testing "Correct error"
-mygrep "\* At step .* process P exited abnormally"
+mygrep "\* At step .* process <P> exited abnormally"
 good
 
 print_blue "Part 2"

--- a/tests/suites/basic_tests/results/process_info-test2-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/process_info-test2-inf-dpor.txt
@@ -1,0 +1,1 @@
+  Summary: 3 errors, 3/3 interleavings explored

--- a/tests/suites/basic_tests/results/sched_tests-test_send_3-0-dpor.txt
+++ b/tests/suites/basic_tests/results/sched_tests-test_send_3-0-dpor.txt
@@ -1,0 +1,1 @@
+Checked 1 interleaving(s). No errors found.

--- a/tests/suites/basic_tests/results/sched_tests-test_send_3-0.txt
+++ b/tests/suites/basic_tests/results/sched_tests-test_send_3-0.txt
@@ -1,0 +1,1 @@
+Checked 1 interleaving(s). No errors found.

--- a/tests/suites/basic_tests/results/sched_tests-test_send_3-1-dpor.txt
+++ b/tests/suites/basic_tests/results/sched_tests-test_send_3-1-dpor.txt
@@ -1,0 +1,1 @@
+Checked 1 interleaving(s). No errors found.

--- a/tests/suites/basic_tests/results/sched_tests-test_send_3-1.txt
+++ b/tests/suites/basic_tests/results/sched_tests-test_send_3-1.txt
@@ -1,0 +1,1 @@
+Checked 3 interleaving(s). No errors found.

--- a/tests/suites/basic_tests/results/sched_tests-test_send_3-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/sched_tests-test_send_3-inf-dpor.txt
@@ -1,0 +1,16 @@
+################################################################################
+Concuerror started with options:
+  [{'after-timeout',infinite},
+   {bound,-1},
+   {distributed,true},
+   {files,["/home/stavros/git/Concuerror/tests/suites/basic_tests/src/sched_tests.erl"]},
+   {'light-dpor',false},
+   {symbolic,true},
+   {target,{sched_tests,test_send_2,[]}},
+   {verbose,0},
+   {wait,5000}]
+################################################################################
+  No errors found!
+################################################################################
+Done! (Exit status: completed)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/sched_tests-test_send_3-inf.txt
+++ b/tests/suites/basic_tests/results/sched_tests-test_send_3-inf.txt
@@ -1,0 +1,1 @@
+Checked 3 interleaving(s). No errors found.

--- a/tests/suites/basic_tests/src/process_info.erl
+++ b/tests/suites/basic_tests/src/process_info.erl
@@ -1,11 +1,16 @@
 -module(process_info).
 
--export([test1/0]).
+-export([test1/0, test2/0]).
 -export([scenarios/0]).
 
-scenarios() -> [{T, inf, dpor} || T <- [test1]].
+scenarios() -> [{T, inf, dpor} || T <- [test1, test2]].
 
 test1() ->
     Fun = fun() -> register(foo, self()) end,
     P = spawn(Fun),
     exit(process_info(P, registered_name)).
+
+test2() ->
+    Fun = fun() -> register(foo, self()) end,
+    P = spawn(Fun),
+    exit(process_info(P, [registered_name, group_leader])).

--- a/tests/suites/basic_tests/src/sched_tests.erl
+++ b/tests/suites/basic_tests/src/sched_tests.erl
@@ -15,7 +15,7 @@
 -module(sched_tests).
 -export([scenarios/0]).
 -export([test_spawn/0,
-     test_send/0, test_send_2/0,
+     test_send/0, test_send_2/0, test_send_3/0,
      test_receive/0, test_receive_2/0,
      test_send_receive/0, test_send_receive_2/0, test_send_receive_3/0,
      test_receive_after_no_patterns/0, test_receive_after_with_pattern/0,
@@ -60,6 +60,7 @@ scenario_names() ->
     [{test_spawn, 0}, {test_spawn, 1}, {test_spawn, inf}
     ,{test_send, 0}, {test_send, 1}, {test_send, inf}
     ,{test_send_2, 0}, {test_send_2, 1}, {test_send_2, inf}
+    ,{test_send_3, 0}, {test_send_3, 1}, {test_send_3, inf}
     ,{test_receive, 0}, {test_receive, inf}
     ,{test_receive_2, 0}, {test_receive_2, inf}
     ,{test_send_receive, 0}, {test_send_receive, 1}
@@ -158,7 +159,14 @@ test_send() ->
 
 test_send_2() ->
     Pid = spawn(fun() -> ok end),
-    erlang:send(Pid, foo),
+    foo = erlang:send(Pid, foo),
+    ok.
+
+-spec test_send_3() -> 'ok'.
+
+test_send_3() ->
+    Pid = spawn(fun() -> ok end),
+    ok = erlang:send(Pid, foo, [noconnect]),
     ok.
 
 -spec test_receive() -> no_return().


### PR DESCRIPTION
## Summary

* List processes with their registered name
* Fix erlang:send/3 return value
* Add support for erlang:process_info/2 with a list argument

**Important**: the new test for `process_info/2` is currently broken. I get this output when running it, and I don't know how to fix it:

```
* The following pair of instructions is not explicitly marked as non-racing in Concuerror's internals:
  1) [{registered_name,[]},{group_leader,<0.74.0>}] = erlang:process_info(<0.85.0>, [registered_name,group_leader])
  2) true = erlang:register(foo, <0.85.0>)
 Please notify the developers to add info about this pair.
 You can run without '--assume_racing false' to treat them as racing.
 [{concuerror_dependencies,dependent_process_info,
      [{builtin_event,<0.82.0>,undefined,false,
           {erlang,process_info,[<0.85.0>,[registered_name,group_leader]]},
           [{registered_name,[]},{group_leader,<0.74.0>}],
           ok,false},
       {builtin_event,<0.85.0>,undefined,false,
           {erlang,register,[foo,<0.85.0>]},
           true,ok,false}],
      [{file,"src/concuerror_dependencies.erl"},{line,338}]},
  {concuerror_dependencies,'-dependent/3-lc$^3/1-3-',5,
      [{file,"src/concuerror_dependencies.erl"},{line,42}]},
  {concuerror_dependencies,dependent,3,
      [{file,"src/concuerror_dependencies.erl"},{line,42}]},
  {concuerror_scheduler,update_clock,4,
      [{file,"src/concuerror_scheduler.erl"},{line,887}]},
  {concuerror_scheduler,update_clock,5,
      [{file,"src/concuerror_scheduler.erl"},{line,870}]},
  {concuerror_scheduler,assign_happens_before,4,
      [{file,"src/concuerror_scheduler.erl"},{line,814}]},
  {concuerror_scheduler,plan_more_interleavings,1,
      [{file,"src/concuerror_scheduler.erl"},{line,774}]},
  {concuerror_scheduler,explore,1,
      [{file,"src/concuerror_scheduler.erl"},{line,238}]}]
```

I didn't want to add a broken result file, so I used a fake one that should work once this bug is fixed.

## Checklist

* [x] Has tests (or doesn't need them)
* [x] Updates CHANGELOG (or too minor)
* [x] References related Issues
