### PR TITLE
Show mailbox contents on deadlock (and other minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - untested code for 'hijacking' processes (e.g. application_controller (#2))
 
 ### Changed
+- report shows mailbox contents when a deadlock is detected
 - significantly optimized DPOR implementations
 - moved concuerror executable to /bin directory
 

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -1955,7 +1955,7 @@ is_active(Status) when is_atom(Status) ->
   (Status =:= running) orelse (Status =:= waiting).
 
 get_stacktrace(Top) ->
-  Trace = erlang:get_stacktrace(),
+  {_, Trace} = erlang:process_info(self(), current_stacktrace),
   [T || {M,_,_,_} = T <- Top ++ Trace, not_concuerror_module(M)].
 
 not_concuerror_module(Atom) ->

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -399,8 +399,9 @@ run_built_in(erlang, group_leader, 0, [], Info) ->
   Leader = get_leader(Info, self()),
   {Leader, Info};
 
-run_built_in(erlang, group_leader, 2, [GroupLeader, Pid],
-             #concuerror_info{processes = Processes} = Info) ->
+run_built_in(M, group_leader, 2, [GroupLeader, Pid],
+             #concuerror_info{processes = Processes} = Info)
+  when M =:= erlang; M =:= erts_internal ->
   try
     {true, Info} = run_built_in(erlang, is_process_alive, 1, [Pid], Info),
     {true, Info} = run_built_in(erlang, is_process_alive, 1, [GroupLeader], Info),

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -89,8 +89,7 @@
           links                       :: links(),
           logger                      :: pid(),
           message_counter = 1         :: pos_integer(),
-          messages_new = queue:new()  :: message_queue(),
-          messages_old = queue:new()  :: message_queue(),
+          message_queue = queue:new() :: message_queue(),
           monitors                    :: monitors(),
           event = none                :: 'none' | event(),
           notify_when_ready           :: {pid(), boolean()},
@@ -579,10 +578,10 @@ run_built_in(erlang, process_info, 2, [Pid, Item], Info) when is_atom(Item) ->
             catch error:badarg -> []
             end;
           messages ->
-            #concuerror_info{messages_new = Queue} = TheirInfo,
+            #concuerror_info{message_queue = Queue} = TheirInfo,
             [M || #message{data = M} <- queue:to_list(Queue)];
           message_queue_len ->
-            #concuerror_info{messages_new = Queue} = TheirInfo,
+            #concuerror_info{message_queue = Queue} = TheirInfo,
             queue:len(Queue);
           registered_name ->
             #concuerror_info{processes = Processes} = TheirInfo,
@@ -1248,9 +1247,73 @@ handle_receive(PatternFun, Timeout, Location, Info) ->
   %% the queue anyway...
   {MessageOrAfter, NewInfo} =
     has_matching_or_after(PatternFun, Timeout, Location, Info, blocking),
-  handle_receive(MessageOrAfter, PatternFun, Timeout, Location, NewInfo).
+  notify_receive(MessageOrAfter, PatternFun, Timeout, Location, NewInfo).
 
-handle_receive(MessageOrAfter, PatternFun, Timeout, Location, Info) ->
+has_matching_or_after(PatternFun, Timeout, Location, InfoIn, Mode) ->
+  case Mode of
+    non_blocking ->
+      has_matching_or_after(PatternFun, Timeout, InfoIn);
+    blocking ->
+      {Result, Info} = has_matching_or_after(PatternFun, Timeout, InfoIn),
+      case Result =:= false of
+        true ->
+          ?debug_flag(?loop, blocked),
+          NewInfo =
+            case Info#concuerror_info.status =:= waiting of
+              true ->
+                Messages = Info#concuerror_info.message_queue,
+                MessageList = [D || #message{data = D} <- queue:to_list(Messages)],
+                Notification = {blocked, Location, MessageList},
+                process_loop(notify(Notification, Info));
+              false ->
+                process_loop(set_status(Info, waiting))
+            end,
+          has_matching_or_after(PatternFun, Timeout, Location, NewInfo, Mode);
+        false ->
+          ?debug_flag(?loop, ready_to_receive),
+          NewInfo = process_loop(InfoIn),
+          {FinalResult, FinalInfo} =
+            has_matching_or_after(PatternFun, Timeout, NewInfo),
+          {FinalResult, FinalInfo}
+      end
+  end.
+
+has_matching_or_after(PatternFun, Timeout, Info) ->
+  #concuerror_info{message_queue = Messages} = Info,
+  {MatchingOrFalse, NewMessages} = find_matching_message(PatternFun, Messages),
+  Result =
+    case MatchingOrFalse =:= false of
+      false -> MatchingOrFalse;
+      true ->
+        case Timeout =:= infinity of
+          false -> 'after';
+          true -> false
+        end
+    end,
+  {Result, Info#concuerror_info{message_queue = NewMessages}}.
+
+find_matching_message(PatternFun, Messages) ->
+  find_matching_message(PatternFun, Messages, queue:new()).
+
+find_matching_message(PatternFun, NewMessages, OldMessages) ->
+  {Value, NewNewMessages} = queue:out(NewMessages),
+  ?debug_flag(?receive_, {inspect, Value}),
+  case Value of
+    {value, #message{data = Data} = Message} ->
+      case PatternFun(Data) of
+        true  ->
+          ?debug_flag(?receive_, matches),
+          {Message, queue:join(OldMessages, NewNewMessages)};
+        false ->
+          ?debug_flag(?receive_, doesnt_match),
+          NewOldMessages = queue:in(Message, OldMessages),
+          find_matching_message(PatternFun, NewNewMessages, NewOldMessages)
+      end;
+    empty ->
+      {false, OldMessages}
+  end.
+
+notify_receive(MessageOrAfter, PatternFun, Timeout, Location, Info) ->
   {Cnt, ReceiveInfo} = get_receive_cnt(Info),
   #concuerror_info{
      event = NextEvent,
@@ -1280,81 +1343,6 @@ handle_receive(MessageOrAfter, PatternFun, Timeout, Location, Info) ->
         false
     end,
   {{skip_timeout, AddMessage}, delay_notify(Notification, UpdatedInfo)}.
-
-has_matching_or_after(PatternFun, Timeout, Location, InfoIn, Mode) ->
-  {Result, NewOldMessages} = has_matching_or_after(PatternFun, Timeout, InfoIn),
-  UpdatedInfo = update_messages(Result, NewOldMessages, InfoIn),
-  case Mode of
-    non_blocking -> {Result, UpdatedInfo};
-    blocking ->
-      case Result =:= false of
-        true ->
-          ?debug_flag(?loop, blocked),
-          NewInfo =
-            case InfoIn#concuerror_info.status =:= waiting of
-              true ->
-                MessageList = [D || #message{data = D} <- queue:to_list(NewOldMessages)],
-                Notification = {blocked, Location, MessageList},
-                process_loop(notify(Notification, UpdatedInfo));
-              false ->
-                process_loop(set_status(UpdatedInfo, waiting))
-            end,
-          has_matching_or_after(PatternFun, Timeout, Location, NewInfo, Mode);
-        false ->
-          ?debug_flag(?loop, ready_to_receive),
-          NewInfo = process_loop(InfoIn),
-          {FinalResult, FinalNewOldMessages} =
-            has_matching_or_after(PatternFun, Timeout, NewInfo),
-          FinalInfo = update_messages(Result, FinalNewOldMessages, NewInfo),
-          {FinalResult, FinalInfo}
-      end
-  end.
-
-update_messages(Result, NewOldMessages, Info) ->
-  case Result =:= false of
-    true ->
-      Info#concuerror_info{
-        messages_new = queue:new(),
-        messages_old = NewOldMessages};
-    false ->
-      Info#concuerror_info{
-        messages_new = NewOldMessages,
-        messages_old = queue:new()}
-  end.      
-
-has_matching_or_after(PatternFun, Timeout, Info) ->
-  #concuerror_info{messages_new = NewMessages,
-                   messages_old = OldMessages} = Info,
-  {Result, NewOldMessages} =
-    fold_with_patterns(PatternFun, NewMessages, OldMessages),
-  AfterOrMessage =
-    case Result =:= false of
-      false -> Result;
-      true ->
-        case Timeout =:= infinity of
-          false -> 'after';
-          true -> false
-        end
-    end,
-  {AfterOrMessage, NewOldMessages}.
-
-fold_with_patterns(PatternFun, NewMessages, OldMessages) ->
-  {Value, NewNewMessages} = queue:out(NewMessages),
-  ?debug_flag(?receive_, {inspect, Value}),
-  case Value of
-    {value, #message{data = Data} = Message} ->
-      case PatternFun(Data) of
-        true  ->
-          ?debug_flag(?receive_, matches),
-          {Message, queue:join(OldMessages, NewNewMessages)};
-        false ->
-          ?debug_flag(?receive_, doesnt_match),
-          NewOldMessages = queue:in(Message, OldMessages),
-          fold_with_patterns(PatternFun, NewNewMessages, NewOldMessages)
-      end;
-    empty ->
-      {false, OldMessages}
-  end.
 
 %%------------------------------------------------------------------------------
 
@@ -1499,10 +1487,10 @@ process_loop(Info) ->
       case is_active(Info) andalso NotDemonitored of
         true ->
           ?debug_flag(?loop, enqueueing_message),
-          Old = Info#concuerror_info.messages_new,
+          Queue = Info#concuerror_info.message_queue,
           NewInfo =
             Info#concuerror_info{
-              messages_new = queue:in(Message, Old)
+              message_queue = queue:in(Message, Queue)
              },
           ?debug_flag(?loop, enqueued_msg),
           case NewInfo#concuerror_info.status =:= waiting of
@@ -1894,8 +1882,7 @@ reset_concuerror_info(Info) ->
     exit_reason = normal,
     flags = #process_flags{},
     message_counter = 1,
-    messages_new = queue:new(),
-    messages_old = queue:new(),
+    message_queue = queue:new(),
     event = none,
     notify_when_ready = {Pid, true},
     receive_counter = 1,

--- a/src/concuerror_io_lib.erl
+++ b/src/concuerror_io_lib.erl
@@ -37,8 +37,10 @@ error_s({Type, Info}, Depth) ->
       [S1,S2,S3];
     deadlock ->
       InfoStr =
-        [io_lib:format("    ~p ~s~n", [P, location(F, L)]) ||
-          {P, [L, {file, F}]} <- Info],
+        [io_lib:format(
+           "    ~p ~s~n"
+           "     Mailbox contents: ~p~n", [P, location(F, L), Msgs]) ||
+          {P, [L, {file, F}], Msgs} <- Info],
       Format =
         "* Blocked at a 'receive' (\"deadlocked\"; other processes have exited):~n~s",
       io_lib:format(Format, [InfoStr]);

--- a/src/concuerror_logger.erl
+++ b/src/concuerror_logger.erl
@@ -421,7 +421,9 @@ loop(Message, State) ->
                 undefined ->
                   case proplists:get_value(deadlock, Warnings) of
                     undefined -> "";
-                    Ps -> io_lib:format(" (~p blocked)", [[P || {P,_} <- Ps]])
+                    Deadlocks ->
+                      Pids = [element(1, D) || D <- Deadlocks],
+                      io_lib:format(" (~p blocked)", [Pids])
                   end
               end,
             {Errors + 1, TracesSSB, "Error" ++ ErrorString, "red"}

--- a/src/concuerror_scheduler.erl
+++ b/src/concuerror_scheduler.erl
@@ -492,7 +492,7 @@ free_schedule_1(_Event, [], State) ->
         case concuerror_callback:collect_deadlock_info(Actors) of
           [] -> [];
           Info ->
-            ?debug(_Logger, "Deadlock: ~p~n", [[P || {P,_} <- Info]]),
+            ?debug(_Logger, "Deadlock: ~p~n", [[element(1, I) || I <- Info]]),
             [{deadlock, Info}]
         end
     end,

--- a/tests-real/suites/options/other-tests
+++ b/tests-real/suites/options/other-tests
@@ -4,6 +4,10 @@
 
 print_blue "$0"
 
+testing "Deadlock shows messages"
+! concuerror_console -f src/deadlock.erl
+outputhas "Mailbox contents: \[foo\]"
+
 testing "Can find default in path"
 rm -rf path
 rm -rf foo.beam

--- a/tests-real/suites/options/src/deadlock.erl
+++ b/tests-real/suites/options/src/deadlock.erl
@@ -1,0 +1,10 @@
+-module(deadlock).
+
+-export([test/0]).
+
+test() ->
+  P = self(),
+  spawn(fun() -> P ! foo end),
+  receive
+    bar -> ok
+  end.


### PR DESCRIPTION
## Summary

- Show mailbox contents on deadlocks
- Use process_info(_, current_stacktrace) to retrieve stacktraces
- Generalize support for group_leader (in OTP 21 it belongs to erts_internal)

## Checklist

* [x] Has tests (or doesn't need them)
* [x] Updates CHANGELOG (or too minor)