### PR TITLE
Add erlang-concurrency-litmus-tests as a testsuite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased](https://github.com/parapluu/Concuerror/tree/master)
 
 ### Added
+- Parts of [aronisstav/erlang-concurrency-litmus-tests](https://github.com/aronisstav/erlang-concurrency-litmus-tests) as a testsuite
 - [Coveralls](https://coveralls.io/github/parapluu/Concuerror) code coverage tracking
 - [contributor's guide](./CONTRIBUTING.md)
 - [Github Pull Request and Issue templates](./.github/)

--- a/src/concuerror.hrl
+++ b/src/concuerror.hrl
@@ -145,7 +145,7 @@
 
 -define(process_name_none, 0).
 -define(new_process(Pid, Symbolic),
-        {Pid, running, ?process_name_none, undefined, Symbolic, 0, regular}).
+        {Pid, exited, ?process_name_none, undefined, Symbolic, 0, regular}).
 -define(new_system_process(Pid, Name, Type),
         {Pid, running, Name, undefined, atom_to_list(Name), 0, Type}).
 -define(process_pat_pid(Pid),                {Pid,      _,    _, _, _, _,    _}).

--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -311,6 +311,9 @@ dependent_exit(_Exit, {erlang, A, _})
     A =:= spawn_link;
     A =:= start_timer ->
   false;
+dependent_exit(#exit_event{},
+               {_, group_leader, []}) ->
+  false;
 dependent_exit(#exit_event{actor = Exiting},
                {_, group_leader, [Leader, Leaded]}) ->
   Exiting =:= Leader orelse Exiting =:= Leaded;

--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -311,8 +311,9 @@ dependent_exit(_Exit, {erlang, A, _})
     A =:= spawn_link;
     A =:= start_timer ->
   false;
-dependent_exit(_Exit, {_, group_leader, _}) ->
-  false;
+dependent_exit(#exit_event{actor = Exiting},
+               {_, group_leader, [Leader, Leaded]}) ->
+  Exiting =:= Leader orelse Exiting =:= Leaded;
 dependent_exit(#exit_event{actor = Actor}, {erlang, processes, []}) ->
   is_pid(Actor);
 dependent_exit(#exit_event{actor = Cancelled},

--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -438,53 +438,6 @@ dependent_built_in(#builtin_event{mfargs = {erlang, Spawn, _}},
 
 dependent_built_in(#builtin_event{mfargs = {erlang, A, _}},
                    #builtin_event{mfargs = {erlang, B, _}})
-  when
-    false
-    ;A =:= date
-    ;A =:= demonitor        %% Depends only with an exit event or proc_info
-    ;A =:= exit             %% Sending an exit signal (dependencies are on delivery)
-    ;A =:= get_stacktrace   %% Depends with nothing
-    ;A =:= is_process_alive %% Depends only with an exit event
-    ;A =:= make_ref         %% Depends with nothing
-    ;A =:= monitor          %% Depends only with an exit event or proc_info
-    ;A =:= now
-    ;A =:= process_flag     %% Depends only with delivery of a signal
-    ;A =:= processes        %% Depends only with spawn and exit
-    ;A =:= send_after
-    ;A =:= spawn            %% Depends only with processes/0
-    ;A =:= spawn_link       %% Depends only with processes/0
-    ;A =:= spawn_opt        %% Depends only with processes/0
-    ;A =:= start_timer
-    ;A =:= time
-    
-    ;B =:= date
-    ;B =:= demonitor
-    ;B =:= exit
-    ;B =:= get_stacktrace
-    ;B =:= is_process_alive
-    ;B =:= make_ref
-    ;B =:= monitor
-    ;B =:= now
-    ;B =:= process_flag
-    ;B =:= processes
-    ;B =:= send_after
-    ;B =:= spawn
-    ;B =:= spawn_link
-    ;B =:= spawn_opt
-    ;B =:= start_timer
-    ;B =:= time
-    ->
-  false;
-
-dependent_built_in(#builtin_event{mfargs = {_, group_leader, _}},
-                   #builtin_event{}) ->
-  false;
-dependent_built_in(#builtin_event{},
-                   #builtin_event{mfargs = {_, group_leader, _}}) ->
-  false;
-
-dependent_built_in(#builtin_event{mfargs = {erlang, A, _}},
-                   #builtin_event{mfargs = {erlang, B, _}})
   when (A =:= '!' orelse A =:= send orelse A =:= whereis orelse
         A =:= process_flag orelse A =:= link orelse A =:= unlink),
        (B =:= '!' orelse B =:= send orelse B =:= whereis orelse
@@ -511,6 +464,16 @@ dependent_built_in(#builtin_event{mfargs = {erlang,UnRegisterOp,_}} = R,
        (SendOrWhereis =:= '!' orelse SendOrWhereis =:= send orelse
         SendOrWhereis =:= whereis) ->
   dependent_built_in(S, R);
+
+dependent_built_in(#builtin_event{mfargs = {erlang,monitor,[process,SName]}},
+                   #builtin_event{mfargs = {erlang,UnRegisterOp,[RName|_]}})
+  when (UnRegisterOp =:= register orelse UnRegisterOp =:= unregister) ->
+  SName =:= RName;
+dependent_built_in(#builtin_event{mfargs = {erlang,UnRegisterOp,_}} = R,
+                   #builtin_event{mfargs = {erlang,monitor,_}} = S)
+  when (UnRegisterOp =:= register orelse UnRegisterOp =:= unregister) ->
+  dependent_built_in(S, R);
+
 dependent_built_in(#builtin_event{mfargs = {erlang,RegistryOp,_}},
                    #builtin_event{mfargs = {erlang,LinkOp,_}})
   when (RegistryOp =:= register orelse 
@@ -549,6 +512,53 @@ dependent_built_in(#builtin_event{},
                    #builtin_event{mfargs = {erlang,ReadorCancelTimer,_}})
   when ReadorCancelTimer =:= read_timer;
        ReadorCancelTimer =:= cancel_timer ->
+  false;
+
+dependent_built_in(#builtin_event{mfargs = {erlang, A, _}},
+                   #builtin_event{mfargs = {erlang, B, _}})
+  when
+    false
+    ;A =:= date
+    ;A =:= demonitor        %% Depends only with an exit event or proc_info
+    ;A =:= exit             %% Sending an exit signal (dependencies are on delivery)
+    ;A =:= get_stacktrace   %% Depends with nothing
+    ;A =:= is_process_alive %% Depends only with an exit event
+    ;A =:= make_ref         %% Depends with nothing
+    ;A =:= monitor          %% Depends only with an exit event or proc_info
+    ;A =:= now
+    ;A =:= process_flag     %% Depends only with delivery of a signal
+    ;A =:= processes        %% Depends only with spawn and exit
+    ;A =:= send_after
+    ;A =:= spawn            %% Depends only with processes/0
+    ;A =:= spawn_link       %% Depends only with processes/0
+    ;A =:= spawn_opt        %% Depends only with processes/0
+    ;A =:= start_timer
+    ;A =:= time
+
+    ;B =:= date
+    ;B =:= demonitor
+    ;B =:= exit
+    ;B =:= get_stacktrace
+    ;B =:= is_process_alive
+    ;B =:= make_ref
+    ;B =:= monitor
+    ;B =:= now
+    ;B =:= process_flag
+    ;B =:= processes
+    ;B =:= send_after
+    ;B =:= spawn
+    ;B =:= spawn_link
+    ;B =:= spawn_opt
+    ;B =:= start_timer
+    ;B =:= time
+    ->
+  false;
+
+dependent_built_in(#builtin_event{mfargs = {_, group_leader, _}},
+                   #builtin_event{}) ->
+  false;
+dependent_built_in(#builtin_event{},
+                   #builtin_event{mfargs = {_, group_leader, _}}) ->
   false;
 
 %%------------------------------------------------------------------------------

--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -425,6 +425,28 @@ dependent_built_in(#builtin_event{mfargs = {_,group_leader,ArgsA}} = A,
       ForA =:= ForB
   end;
 
+dependent_built_in(#builtin_event{actor = A, mfargs = {erlang, Spawn, _}},
+                   #builtin_event{mfargs = {_, group_leader, [_, Leaded]}})
+  when
+    Spawn =:= spawn;
+    Spawn =:= spawn_link;
+    Spawn =:= spawn_opt ->
+  Leaded =:= A;
+dependent_built_in(#builtin_event{mfargs = {_, group_leader, [_, Leaded]}},
+                   #builtin_event{actor = A, mfargs = {erlang, Spawn, _}})
+  when
+    Spawn =:= spawn;
+    Spawn =:= spawn_link;
+    Spawn =:= spawn_opt ->
+  Leaded =:= A;
+
+dependent_built_in(#builtin_event{mfargs = {_, group_leader, _}},
+                   #builtin_event{}) ->
+  false;
+dependent_built_in(#builtin_event{},
+                   #builtin_event{mfargs = {_, group_leader, _}}) ->
+  false;
+
 dependent_built_in(#builtin_event{mfargs = {erlang, processes, []}},
                    #builtin_event{mfargs = {erlang, Spawn, _}})
   when
@@ -567,13 +589,6 @@ dependent_built_in(#builtin_event{mfargs = {erlang, A, _}},
     ;B =:= start_timer
     ;B =:= time
     ->
-  false;
-
-dependent_built_in(#builtin_event{mfargs = {_, group_leader, _}},
-                   #builtin_event{}) ->
-  false;
-dependent_built_in(#builtin_event{},
-                   #builtin_event{mfargs = {_, group_leader, _}}) ->
   false;
 
 %%------------------------------------------------------------------------------

--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -491,6 +491,17 @@ dependent_built_in(#builtin_event{mfargs = {erlang,LinkOp,_}} = L,
         LinkOp =:= unlink) ->
   dependent_built_in(R, L);
 
+dependent_built_in(#builtin_event{mfargs = {erlang,ReadorCancelTimerA,[TimerA]}},
+                   #builtin_event{mfargs = {erlang,ReadorCancelTimerB,[TimerB]}})
+  when (ReadorCancelTimerA =:= read_timer orelse
+        ReadorCancelTimerA =:= cancel_timer),
+       (ReadorCancelTimerB =:= read_timer orelse
+        ReadorCancelTimerB =:= cancel_timer),
+       (ReadorCancelTimerA =:= cancel_timer orelse
+        ReadorCancelTimerB =:= cancel_timer)
+       ->
+  TimerA =:= TimerB;
+
 dependent_built_in(#builtin_event{mfargs = {erlang,send,_}, extra = Extra},
                    #builtin_event{mfargs = {erlang,ReadorCancelTimer,[Timer]}})
   when is_reference(Extra),

--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -353,7 +353,7 @@ dependent_exit(_Exit, {ets, _, _}) ->
 dependent_process_info(#builtin_event{mfargs = {_,_,[Pid, group_leader]}},
                        Other) ->
   case Other of
-    #builtin_event{mfargs = {_,group_leader,[Pid,_]}} -> true;
+    #builtin_event{mfargs = {_,group_leader,[_, Pid]}} -> true;
     _-> false
   end;
 dependent_process_info(#builtin_event{mfargs = {_,_,[Pid, links]}},

--- a/tests-real/suites/erlang-litmus/.gitignore
+++ b/tests-real/suites/erlang-litmus/.gitignore
@@ -1,0 +1,1 @@
+erlang-concurrency-litmus-tests

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test
 
 test: erlang-concurrency-litmus-tests
+	#./test etsglobal # Skip: The tests are incomplete and a bit
+	#                 #       irrelevant for Concuerror right now
 	./test leader
 	./test link
 	./test mailbox
@@ -8,8 +10,6 @@ test: erlang-concurrency-litmus-tests
 	./test registry
 	./test signal
 	./test timer
-
-#./test . #When everything works
 
 erlang-concurrency-litmus-tests:
 	git clone https://github.com/aronisstav/erlang-concurrency-litmus-tests.git

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -3,6 +3,7 @@
 test: erlang-concurrency-litmus-tests
 	./test mailbox
 	./test link
+	./test registry
 
 #./test . #When everything works
 

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -5,6 +5,7 @@ test: erlang-concurrency-litmus-tests
 	./test mailbox
 	./test process
 	./test registry
+	./test signal
 	./test timer
 
 #./test . #When everything works

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -1,8 +1,8 @@
 .PHONY: test
 
 test: erlang-concurrency-litmus-tests
-	./test mailbox
 	./test link
+	./test mailbox
 	./test registry
 	./test timer
 

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -2,6 +2,8 @@
 
 test: erlang-concurrency-litmus-tests
 	./test mailbox
+	./test link
+
 #./test . #When everything works
 
 erlang-concurrency-litmus-tests:

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -1,6 +1,7 @@
 .PHONY: test
 
 test: erlang-concurrency-litmus-tests
+	./test leader
 	./test link
 	./test mailbox
 	./test process

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test
+
+test: erlang-concurrency-litmus-tests
+	./test mailbox
+#./test . #When everything works
+
+erlang-concurrency-litmus-tests:
+	git clone https://github.com/aronisstav/erlang-concurrency-litmus-tests.git

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -3,6 +3,7 @@
 test: erlang-concurrency-litmus-tests
 	./test link
 	./test mailbox
+	./test process
 	./test registry
 	./test timer
 

--- a/tests-real/suites/erlang-litmus/Makefile
+++ b/tests-real/suites/erlang-litmus/Makefile
@@ -4,6 +4,7 @@ test: erlang-concurrency-litmus-tests
 	./test mailbox
 	./test link
 	./test registry
+	./test timer
 
 #./test . #When everything works
 

--- a/tests-real/suites/erlang-litmus/run_litmus.escript
+++ b/tests-real/suites/erlang-litmus/run_litmus.escript
@@ -6,7 +6,7 @@
 
 options() ->
   "--assertions_only -v0 --ignore_error deadlock"
-    " --instant_delivery false".
+    " --instant_delivery false --assume_racing false".
 
 %%%-----------------------------------------------------------------------------
 
@@ -29,7 +29,6 @@ main(Tests) ->
     false -> os:putenv("CONCUERROR","concuerror");
     _ -> ok
   end,
-  to_stderr("~p",[Tests]),
   Server = initialize(),
   ok = inspect_files(Tests, Server),
   finish(Server).

--- a/tests-real/suites/erlang-litmus/run_litmus.escript
+++ b/tests-real/suites/erlang-litmus/run_litmus.escript
@@ -1,0 +1,220 @@
+#!/usr/bin/env escript
+%% -*- erlang-indent-level: 2 -*-
+%%! +S1 -noshell
+
+%%% This script can be used to run Concuerror on specified tests.
+
+options() ->
+  "--assertions_only -v0 --ignore_error deadlock"
+    " --instant_delivery false".
+
+%%%-----------------------------------------------------------------------------
+
+%%% Names and expected exit values from running concuerror on litmus tests
+
+expected_exit(exhaustive) -> 0;
+expected_exit(possible_1) -> 1;
+expected_exit(possible_2) -> 1;
+expected_exit(possible_3) -> 1;
+expected_exit(_) -> -1.
+
+%%%-----------------------------------------------------------------------------
+
+main([]) ->
+  %% Implied argument: all tests below
+  {ok, Cwd} = file:get_cwd(),
+  main([Cwd]);
+main(Tests) ->
+  case os:getenv("CONCUERROR") of
+    false -> os:putenv("CONCUERROR","concuerror");
+    _ -> ok
+  end,
+  to_stderr("~p",[Tests]),
+  Server = initialize(),
+  ok = inspect_files(Tests, Server),
+  finish(Server).
+
+%%%-----------------------------------------------------------------------------
+
+-record(
+   state,
+   {
+     done   = 0
+   , failed = 0
+   , files  = 0
+   , finish = false
+   , limit  = 2
+   , tests  = 0
+   }).
+
+initialize() ->
+  print_header(),
+  spawn_link(fun() -> loop(#state{}) end).
+
+loop(#state{done = All, finish = {true, Report}, tests = All} = State) ->
+  #state{failed = Failed, files = Files, tests = Tests} = State,
+  Report ! {finish, Files, Tests, Failed},
+  ok;
+loop(State) ->
+  #state{
+     done = Done,
+     failed = Failed,
+     files = Files,
+     limit = Limit,
+     tests = Tests
+    } = State,
+  receive
+    {file, File, Names} when Limit > 0 ->
+      Server = self(),
+      _ = [spawn_link(fun() -> run_test(File, T, Server) end) || T <- Names],
+      NewFiles = Files + 1,
+      NewTests = Tests + length(Names),
+      NewLimit = Limit - length(Names),
+      loop(State#state{files = NewFiles, limit = NewLimit, tests = NewTests});
+    {test, File, Test, Status} ->
+      print_test(File, Test, Status),
+      NewDone = Done + 1,
+      NewLimit = Limit + 1,
+      NewFailed =
+        case Status =:= ok of
+          true -> Failed;
+          false -> Failed + 1
+        end,
+      loop(State#state{done = NewDone, failed = NewFailed, limit = NewLimit});
+    {finish, Report} when Limit > 0 ->
+      loop(State#state{finish = {true, Report}})
+  end.
+
+%%%-----------------------------------------------------------------------------
+
+run_test(File, Test, Server) ->
+  Basename = filename:basename(File, ".erl"),
+  Out = io_lib:format("~s-~p.out",[Basename, Test]),
+  Opts = options(),
+  Command =
+    io_lib:format("$CONCUERROR ~s -f ~s -t ~p -o ~s", [Opts, File, Test, Out]),
+  Exit = run_and_get_exit_status(Command),
+  Status =
+    case Exit =:= expected_exit(Test) of
+      true ->
+        file:delete(Out),
+        ok;
+      false ->
+        failed
+    end,
+  Server ! {test, File, Test, Status}.
+
+run_and_get_exit_status(Command) ->
+  Port = open_port({spawn, Command}, [stream, in, eof, hide, exit_status]),
+  get_exit(Port, infinity).
+
+get_exit(Port, Timeout) ->
+  receive
+    {Port, {exit_status, ExitStatus}} ->
+      get_exit(Port, 0),
+      ExitStatus;
+    {Port, _} ->
+      get_exit(Port, Timeout);
+    {'EXIT', Port, _} ->
+      get_exit(Port, Timeout)
+  after
+    Timeout -> ok
+  end.
+
+%%%-----------------------------------------------------------------------------
+
+inspect_files([], _Server) ->
+  ok;
+inspect_files([File|Rest], Server) ->
+  case filelib:is_dir(File) of
+    true ->
+      {ok, Files} = file:list_dir(File),
+      inspect_files([filename:join([File, F]) || F <- Files] ++ Rest, Server);
+    false ->
+      extract_tests(File, Server),
+      inspect_files(Rest, Server)
+  end.
+
+extract_tests(File, Server) ->
+  case filename:extension(File) =:= ".erl" of
+    false -> ok;
+    true ->
+      case compile:file(File, [binary]) of
+        error ->
+          print_test(File, 'n/a', skip),
+          ok;
+        {ok, Module, Binary} ->
+          {module, Module} = code:load_binary(Module, File, Binary),
+          Exports = Module:module_info(exports),
+          Tests = [Name || {Name, 0} <- Exports, is_test(Name)],
+          case Tests =:= [] of
+            true -> ok;
+            false ->
+              Server ! {file, File, Tests},
+              ok
+          end
+      end
+  end.
+
+is_test(Name) -> expected_exit(Name) >= 0.
+
+%%%-----------------------------------------------------------------------------
+
+finish(Server) ->
+  Server ! {finish, self()},
+  receive
+    {finish, Files, Tests, Failed} ->
+      print_footer(Files, Tests, Failed),
+      case Failed =:= 0 of
+        true -> halt(0);
+        false -> halt(1)
+      end
+  end.
+
+%%%-----------------------------------------------------------------------------
+
+print_header() ->
+  to_stderr("~-61s~-12s~-7s",["File", "Test", "Result"]),
+  print_line().
+
+print_test(File, Test, Status) ->
+  TBasename = trim(File, 61),
+  TTest = trim(Test, 12),
+  TStatus = trim(Status, 7),
+  Bold = "\033[1m",
+  Color =
+    case Status of
+      ok -> "\033[92m";
+      skip -> "\033[94m";
+      _ -> "\033[91m"
+    end,
+  EndC = "\033[0m",
+  to_stderr(
+    "~-61s~-12s~s~s~-7s~s",
+    [TBasename, TTest, Bold, Color, TStatus, EndC]
+   ).
+
+trim(Atom, Length) when is_atom(Atom) ->
+  trim(atom_to_list(Atom), Length);
+trim(String, Length) ->
+  Flat = lists:flatten(String),
+  case length(Flat) =< Length of
+    true -> Flat;
+    false ->
+      Trim = lists:sublist(String, Length - 4),
+      [Trim,"... "]
+  end.
+
+print_footer(Files, Tests, Failed) ->
+  print_line(),
+  to_stderr("  Suites: ~p", [Files]),
+  to_stderr("   Tests: ~p", [Tests]),
+  to_stderr("  Failed: ~p", [Failed]).
+
+print_line() ->
+  to_stderr("~80..-s", [""]).
+
+%%%-----------------------------------------------------------------------------
+
+to_stderr(Format, Data) ->
+  io:format(standard_error, Format ++ "~n", Data).

--- a/tests-real/suites/erlang-litmus/test
+++ b/tests-real/suites/erlang-litmus/test
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+REPO="erlang-concurrency-litmus-tests"
+
+CONCUERROR=${CONCUERROR:-$(which concuerror)}
+
+. ../print_colors
+
+function abort {
+    cat *.out
+    print_red "FAILED"
+}
+
+set -e
+trap 'abort' 0
+
+print_blue "Litmus Suite $1"
+
+cd $REPO/litmus
+
+../../run_litmus.escript $1
+
+trap - 0
+
+print_green "SUCCESS!"

--- a/tests/suites/basic_tests/results/group_leader3-test-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/group_leader3-test-inf-dpor.txt
@@ -1,0 +1,45 @@
+Concuerror v0.18-178-g56f492 started at 29 Mar 2018 19:04:34
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{group_leader3,test,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/group_leader3.erl"]},
+   {ignore_error,[deadlock]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Warnings:
+--------------------------------------------------------------------------------
+* Some errors were ignored ('--ignore_error').
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Instrumented & loaded module group_leader3
+* Automatically instrumented module erlang
+* You can see pairs of racing instructions (in the report and '--graph') with '--show_races true'
+
+################################################################################
+Done at 29 Mar 2018 19:04:35 (Exit status: ok)
+  Summary: 0 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/src/group_leader3.erl
+++ b/tests/suites/basic_tests/src/group_leader3.erl
@@ -1,0 +1,14 @@
+-module(group_leader3).
+
+-export([scenarios/0]).
+-export([test/0]).
+
+-concuerror_options_forced([{ignore_error, deadlock}]).
+
+scenarios() ->
+    [{test, inf, dpor}].
+
+test() ->
+  P = spawn(fun() -> receive after infinity -> ok end end),
+  spawn(fun() -> group_leader(self(), P) end),
+  process_info(P, group_leader).


### PR DESCRIPTION
## Summary

Start using the aronisstav/erlang-concurrency-litmus-tests repository as a source of tests

Fixes #135.

## Checklist

* [x] Has tests 😄 
* [x] Updates CHANGELOG
* [x] Investigate n/a results in 17
  * Litmus tests are failing to compile in 17 and earlier because `assert.hrl` was not yet independent from `eunit.hrl`.