### PR TITLE
Increase litmus concurrency limit

### DIFF
--- a/tests-real/suites/erlang-litmus/run_litmus.escript
+++ b/tests-real/suites/erlang-litmus/run_litmus.escript
@@ -42,7 +42,7 @@ main(Tests) ->
    , failed = 0
    , files  = 0
    , finish = false
-   , limit  = 2
+   , limit  = 4
    , tests  = 0
    }).
 


### PR DESCRIPTION
## Summary
A build on master was hanging with the previous 2 limit. Increase it "arbitrarily" to a value that works.