### PR TITLE
Refine dependencies of ets operations using a match spec

### DIFF
--- a/tests/suites/basic_tests/results/ets_select-match_against_different_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_against_different_keys-inf-dpor.txt
@@ -1,0 +1,105 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:16
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_against_different_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2653560065.69730305.163627>} = erlang:spawn_opt({ets,match,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   6: <P.1>: [[]] = ets:match(2, {foo,'_'})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.2653560065.69730305.163627>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2653560065.69730305.163627>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.2653560065.69730305.163627>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2653560065.69730305.163627>} = erlang:spawn_opt({ets,match,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [[]] = ets:match(2, {foo,'_'})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.2653560065.69730305.163627>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2653560065.69730305.163627>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.2653560065.69730305.163627>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:delete(2, 2)
+     6: <P.1>: [[]] = ets:match(2, {foo,'_'})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:17 (Exit status: error)
+TODO: there is no real dependency between these operations, but the checks cannot recognize this yet
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_against_different_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_against_different_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:22
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_against_different_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.618931909.1680080897.69266>} = erlang:spawn_opt({ets,match,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   6: <P.1>: [[]] = ets:match(2, {foo,'_'})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.618931909.1680080897.69266>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.618931909.1680080897.69266>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.618931909.1680080897.69266>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.618931909.1680080897.69266>} = erlang:spawn_opt({ets,match,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [[]] = ets:match(2, {foo,'_'})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.618931909.1680080897.69266>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.618931909.1680080897.69266>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.618931909.1680080897.69266>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+     6: <P.1>: [[]] = ets:match(2, {foo,'_'})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:23 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_against_different_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_against_different_tuples-inf-dpor.txt
@@ -1,0 +1,73 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:22
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_against_different_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.1248932650.1680080897.1397>} = erlang:spawn_opt({ets,match,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {21,1})
+    in ets_select.erl line 164
+   6: <P.1>: [[],[],[],[],[]] = ets:match(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.1248932650.1680080897.1397>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.1248932650.1680080897.1397>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.1248932650.1680080897.1397>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:23 (Exit status: error)
+  Summary: 1 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_against_matching_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_against_matching_keys-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:16
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_against_matching_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.501922953.69730305.162020>} = erlang:spawn_opt({ets,match,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   6: <P.1>: [[],[],[],[]] = ets:match(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.501922953.69730305.162020>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.501922953.69730305.162020>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.501922953.69730305.162020>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.501922953.69730305.162020>} = erlang:spawn_opt({ets,match,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [[],[],[],[],[]] = ets:match(2, {'_',0})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.501922953.69730305.162020>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.501922953.69730305.162020>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.501922953.69730305.162020>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:delete(2, 2)
+     6: <P.1>: [[],[],[],[]] = ets:match(2, {'_',0})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:17 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_against_matching_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_against_matching_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:16
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_against_matching_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2615001041.69730305.148700>} = erlang:spawn_opt({ets,match,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   6: <P.1>: [] = ets:match(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.2615001041.69730305.148700>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2615001041.69730305.148700>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.2615001041.69730305.148700>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2615001041.69730305.148700>} = erlang:spawn_opt({ets,match,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [[],[],[],[],[]] = ets:match(2, {'_',0})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.2615001041.69730305.148700>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2615001041.69730305.148700>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.2615001041.69730305.148700>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+     6: <P.1>: [] = ets:match(2, {'_',0})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:17 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_against_matching_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_against_matching_tuples-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:16
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_against_matching_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2952167544.69730305.175309>} = erlang:spawn_opt({ets,match,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   6: <P.1>: [[],[],[],[],[],[]] = ets:match(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.2952167544.69730305.175309>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2952167544.69730305.175309>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.2952167544.69730305.175309>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2952167544.69730305.175309>} = erlang:spawn_opt({ets,match,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [[],[],[],[],[]] = ets:match(2, {'_',0})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.2952167544.69730305.175309>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2952167544.69730305.175309>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.2952167544.69730305.175309>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:insert(2, {20,0})
+     6: <P.1>: [[],[],[],[],[],[]] = ets:match(2, {'_',0})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:17 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_object_against_different_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_object_against_different_keys-inf-dpor.txt
@@ -1,0 +1,105 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:27
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_object_against_different_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.462613443.3290431489.78541>} = erlang:spawn_opt({ets,match_object,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   6: <P.1>: [{foo,foo}] = ets:match_object(2, {foo,'_'})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.462613443.3290431489.78541>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.462613443.3290431489.78541>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.462613443.3290431489.78541>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.462613443.3290431489.78541>} = erlang:spawn_opt({ets,match_object,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{foo,foo}] = ets:match_object(2, {foo,'_'})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.462613443.3290431489.78541>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.462613443.3290431489.78541>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.462613443.3290431489.78541>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:delete(2, 2)
+     6: <P.1>: [{foo,foo}] = ets:match_object(2, {foo,'_'})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:28 (Exit status: error)
+TODO: there is no real dependency between these operations, but the checks cannot recognize this yet
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_object_against_different_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_object_against_different_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:28
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_object_against_different_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.587649904.3290955777.122281>} = erlang:spawn_opt({ets,match_object,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   6: <P.1>: [{foo,foo}] = ets:match_object(2, {foo,'_'})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.587649904.3290955777.122281>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.587649904.3290955777.122281>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.587649904.3290955777.122281>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.587649904.3290955777.122281>} = erlang:spawn_opt({ets,match_object,[2,{foo,'_'}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{foo,foo}] = ets:match_object(2, {foo,'_'})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.587649904.3290955777.122281>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.587649904.3290955777.122281>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.587649904.3290955777.122281>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+     6: <P.1>: [{foo,foo}] = ets:match_object(2, {foo,'_'})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:29 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_object_against_different_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_object_against_different_tuples-inf-dpor.txt
@@ -1,0 +1,73 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:27
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_object_against_different_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2156876870.3290431489.214851>} = erlang:spawn_opt({ets,match_object,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {21,1})
+    in ets_select.erl line 164
+   6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:match_object(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.2156876870.3290431489.214851>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2156876870.3290431489.214851>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.2156876870.3290431489.214851>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:28 (Exit status: error)
+  Summary: 1 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_object_against_matching_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_object_against_matching_keys-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:22
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_object_against_matching_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.942005564.1680080897.90418>} = erlang:spawn_opt({ets,match_object,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   6: <P.1>: [{4,0},{6,0},{8,0},{10,0}] = ets:match_object(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.942005564.1680080897.90418>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.942005564.1680080897.90418>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.942005564.1680080897.90418>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.942005564.1680080897.90418>} = erlang:spawn_opt({ets,match_object,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:match_object(2, {'_',0})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.942005564.1680080897.90418>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.942005564.1680080897.90418>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.942005564.1680080897.90418>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:delete(2, 2)
+     6: <P.1>: [{4,0},{6,0},{8,0},{10,0}] = ets:match_object(2, {'_',0})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:23 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_object_against_matching_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_object_against_matching_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:27
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_object_against_matching_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.460960323.3290431489.77902>} = erlang:spawn_opt({ets,match_object,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   6: <P.1>: [] = ets:match_object(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.460960323.3290431489.77902>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.460960323.3290431489.77902>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.460960323.3290431489.77902>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.460960323.3290431489.77902>} = erlang:spawn_opt({ets,match_object,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:match_object(2, {'_',0})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.460960323.3290431489.77902>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.460960323.3290431489.77902>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.460960323.3290431489.77902>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+     6: <P.1>: [] = ets:match_object(2, {'_',0})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:28 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-match_object_against_matching_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-match_object_against_matching_tuples-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:22
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,match_object_against_matching_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2584720296.1680343041.48551>} = erlang:spawn_opt({ets,match_object,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0},{20,0}] = ets:match_object(2, {'_',0})
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.2584720296.1680343041.48551>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2584720296.1680343041.48551>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.2584720296.1680343041.48551>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2584720296.1680343041.48551>} = erlang:spawn_opt({ets,match_object,[2,{'_',0}],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:match_object(2, {'_',0})
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.2584720296.1680343041.48551>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2584720296.1680343041.48551>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.2584720296.1680343041.48551>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:insert(2, {20,0})
+     6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0},{20,0}] = ets:match_object(2, {'_',0})
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:23 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_against_different_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_against_different_keys-inf-dpor.txt
@@ -1,0 +1,105 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:34
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_against_different_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.663334152.606601217.63156>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:delete(2, foo)
+    in ets_select.erl line 164
+   6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.663334152.606601217.63156>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.663334152.606601217.63156>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.663334152.606601217.63156>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.663334152.606601217.63156>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.663334152.606601217.63156>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.663334152.606601217.63156>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:delete(2, foo)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.663334152.606601217.63156>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:delete(2, foo)
+     6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:35 (Exit status: error)
+TODO: there is no real dependency between these operations, but the checks cannot recognize this yet
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_against_different_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_against_different_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:39
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_against_different_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.933889307.1948254209.185483>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 3 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_atom,'$1'},{'=:=','$1','$2'}}],[true]}])
+    in ets_select.erl line 164
+   6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.933889307.1948254209.185483>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.933889307.1948254209.185483>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.933889307.1948254209.185483>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.933889307.1948254209.185483>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.933889307.1948254209.185483>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.933889307.1948254209.185483>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 3 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_atom,'$1'},{'=:=','$1','$2'}}],[true]}])
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.933889307.1948254209.185483>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 3 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_atom,'$1'},{'=:=','$1','$2'}}],[true]}])
+     6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:39 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_against_different_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_against_different_tuples-inf-dpor.txt
@@ -1,0 +1,73 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:39
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_against_different_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2441776133.1948254209.145714>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {21,1})
+    in ets_select.erl line 164
+   6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.2441776133.1948254209.145714>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2441776133.1948254209.145714>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.2441776133.1948254209.145714>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:39 (Exit status: error)
+  Summary: 1 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_against_matching_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_against_matching_keys-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:33
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_against_matching_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.1122294271.338165761.134334>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   6: <P.1>: [{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.1122294271.338165761.134334>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.1122294271.338165761.134334>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.1122294271.338165761.134334>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.1122294271.338165761.134334>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.1122294271.338165761.134334>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.1122294271.338165761.134334>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:delete(2, 2)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.1122294271.338165761.134334>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:delete(2, 2)
+     6: <P.1>: [{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:34 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_against_matching_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_against_matching_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:33
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_against_matching_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.3244699808.338165761.228549>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   6: <P.1>: [] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.3244699808.338165761.228549>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.3244699808.338165761.228549>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.3244699808.338165761.228549>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.3244699808.338165761.228549>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.3244699808.338165761.228549>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.3244699808.338165761.228549>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.3244699808.338165761.228549>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+     6: <P.1>: [] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:34 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_against_matching_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_against_matching_tuples-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:33
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_against_matching_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.346364362.338165761.145705>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0},{20,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.346364362.338165761.145705>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.346364362.338165761.145705>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.346364362.338165761.145705>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.346364362.338165761.145705>} = erlang:spawn_opt({ets,select,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.346364362.338165761.145705>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.346364362.338165761.145705>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.346364362.338165761.145705>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:insert(2, {20,0})
+     6: <P.1>: [{2,0},{4,0},{6,0},{8,0},{10,0},{20,0}] = ets:select(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],['$_']}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:34 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_different_any-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_different_any-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:48
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_different_any,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.629673900.606076929.96121>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 3 = ets:next(2, 2)
+    in ets_select.erl line 164
+   6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.629673900.606076929.96121>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.629673900.606076929.96121>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.629673900.606076929.96121>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.629673900.606076929.96121>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.629673900.606076929.96121>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.629673900.606076929.96121>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 3 = ets:next(2, 2)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.629673900.606076929.96121>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 3 = ets:next(2, 2)
+     6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:49 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_different_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_different_keys-inf-dpor.txt
@@ -1,0 +1,105 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:44
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_different_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.3849719176.3558866945.186672>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: [{foo,foo}] = ets:lookup(2, foo)
+    in ets_select.erl line 164
+   6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.3849719176.3558866945.186672>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.3849719176.3558866945.186672>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.3849719176.3558866945.186672>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.3849719176.3558866945.186672>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.3849719176.3558866945.186672>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.3849719176.3558866945.186672>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: [{foo,foo}] = ets:lookup(2, foo)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.3849719176.3558866945.186672>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: [{foo,foo}] = ets:lookup(2, foo)
+     6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:45 (Exit status: error)
+TODO: there is no real dependency between these operations, but the checks cannot recognize this yet
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_different_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_different_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:48
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_different_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2437357329.606339073.222044>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: [[]] = ets:match(2, {foo,'_'})
+    in ets_select.erl line 164
+   6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.2437357329.606339073.222044>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2437357329.606339073.222044>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.2437357329.606339073.222044>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.2437357329.606339073.222044>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.2437357329.606339073.222044>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.2437357329.606339073.222044>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: [[]] = ets:match(2, {foo,'_'})
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.2437357329.606339073.222044>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: [[]] = ets:match(2, {foo,'_'})
+     6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:49 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_different_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_different_tuples-inf-dpor.txt
@@ -1,0 +1,73 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:45
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_different_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.1791346681.3827564545.65535>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {21,1})
+    in ets_select.erl line 164
+   6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.1791346681.3827564545.65535>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.1791346681.3827564545.65535>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.1791346681.3827564545.65535>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:46 (Exit status: error)
+  Summary: 1 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_any-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_any-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:44
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_matching_any,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.4192442892.3290955777.208182>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: 2 = ets:next(2, 1)
+    in ets_select.erl line 164
+   6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.4192442892.3290955777.208182>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.4192442892.3290955777.208182>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.4192442892.3290955777.208182>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.4192442892.3290955777.208182>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.4192442892.3290955777.208182>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.4192442892.3290955777.208182>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: 3 = ets:next(2, 1)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.4192442892.3290955777.208182>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: 2 = ets:next(2, 1)
+     6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:45 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_keys-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_keys-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:39
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_matching_keys,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.1707409513.1948516353.14959>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: [{2,0}] = ets:lookup(2, 2)
+    in ets_select.erl line 164
+   6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.1707409513.1948516353.14959>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.1707409513.1948516353.14959>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.1707409513.1948516353.14959>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.1707409513.1948516353.14959>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.1707409513.1948516353.14959>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.1707409513.1948516353.14959>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: [] = ets:lookup(2, 2)
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.1707409513.1948516353.14959>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: [{2,0}] = ets:lookup(2, 2)
+     6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:40 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_matchspec-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_matchspec-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:44
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_matching_matchspec,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.3633545087.3558604801.261202>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: [[],[],[],[],[]] = ets:match(2, {'_',0})
+    in ets_select.erl line 164
+   6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.3633545087.3558604801.261202>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.3633545087.3558604801.261202>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.3633545087.3558604801.261202>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.3633545087.3558604801.261202>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.3633545087.3558604801.261202>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.3633545087.3558604801.261202>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: [] = ets:match(2, {'_',0})
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.3633545087.3558604801.261202>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: [[],[],[],[],[]] = ets:match(2, {'_',0})
+     6: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:45 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_tuples-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/ets_select-select_delete_against_matching_tuples-inf-dpor.txt
@@ -1,0 +1,104 @@
+Concuerror v0.18-209-g66daaa started at 17 Apr 2018 14:09:40
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_select,select_delete_against_matching_tuples,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_select.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,true},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.11095656.2216951809.88286>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   6: <P.1>: 6 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   7: <P.1>: exits normally
+   8: <P.1>: {'DOWN',#Ref<0.11095656.2216951809.88286>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.11095656.2216951809.88286>,process,<P.1>,normal})
+    (while exiting)
+   9: <P>: receives message ({'DOWN',#Ref<0.11095656.2216951809.88286>,process,<P.1>,normal})
+    in ets_select.erl line 167
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P> in ets_select.erl line 168
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: 2 = ets:new(table, [public,ordered_set])
+    in ets_select.erl line 158
+   2: <P>: true = ets:insert(2, [{1,1},{2,0},{3,1},{4,0},{5,1},{6,0},{7,1},{8,0},{9,1},{10,0}])
+    in ets_select.erl line 159
+   3: <P>: true = ets:insert(2, [{foo,foo},{bar,bar},{baz,baz}])
+    in ets_select.erl line 160
+   4: <P>: {<P.1>,#Ref<0.11095656.2216951809.88286>} = erlang:spawn_opt({ets,select_delete,[2,[{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}]],[monitor]})
+    in erlang.erl line 2742
+   5: <P.1>: 5 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+   6: <P.1>: exits normally
+   7: <P.1>: {'DOWN',#Ref<0.11095656.2216951809.88286>,process,<P.1>,normal} = erlang:send(<P>, {'DOWN',#Ref<0.11095656.2216951809.88286>,process,<P.1>,normal})
+    (while exiting)
+   8: <P>: true = ets:insert(2, {20,0})
+    in ets_select.erl line 164
+   9: <P>: receives message ({'DOWN',#Ref<0.11095656.2216951809.88286>,process,<P.1>,normal})
+    in ets_select.erl line 167
+--------------------------------------------------------------------------------
+New races found:
+*    5: <P>: true = ets:insert(2, {20,0})
+     6: <P.1>: 6 = ets:select_delete(2, [{{'$1','$2'},[{'andalso',{is_integer,'$1'},{'=:=','$2',0}}],[true]}])
+
+
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_select
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+
+################################################################################
+Done at 17 Apr 2018 14:09:41 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/src/ets_select.erl
+++ b/tests/suites/basic_tests/src/ets_select.erl
@@ -1,0 +1,168 @@
+-module(ets_select).
+
+-concuerror_options_forced([show_races]).
+
+-export([match_against_matching_keys/0,
+         match_against_matching_tuples/0,
+         match_against_matching_matchspec/0,
+         match_against_different_keys/0,
+         match_against_different_tuples/0,
+         match_against_different_matchspec/0,
+         match_object_against_matching_keys/0,
+         match_object_against_matching_tuples/0,
+         match_object_against_matching_matchspec/0,
+         match_object_against_different_keys/0,
+         match_object_against_different_tuples/0,
+         match_object_against_different_matchspec/0,
+         select_against_matching_keys/0,
+         select_against_matching_tuples/0,
+         select_against_matching_matchspec/0,
+         select_against_different_keys/0,
+         select_against_different_tuples/0,
+         select_against_different_matchspec/0,
+         select_delete_against_matching_keys/0,
+         select_delete_against_matching_tuples/0,
+         select_delete_against_matching_any/0,
+         select_delete_against_matching_matchspec/0,
+         select_delete_against_different_keys/0,
+         select_delete_against_different_tuples/0,
+         select_delete_against_different_any/0,
+         select_delete_against_different_matchspec/0
+        ]).
+
+-export([scenarios/0]).
+
+-define(match_foo, {foo, '_'}).
+-define(match_even, {'_', 0}).
+-define(select_even(Res), [{{'$1', '$2'},        % match head
+                            [{'andalso',         % guard
+                              {'is_integer', '$1'},
+                              {'=:=', '$2', 0}
+                             }],
+                            [Res]                % body
+                           }]).
+-define(select_atom(Res), [{{'$1', '$2'},        % match head
+                            [{'andalso',         % guard
+                              {'is_atom', '$1'},
+                              {'=:=', '$1', '$2'}
+                             }],
+                            [Res]                % body
+                           }]).
+
+scenarios() ->
+  [{list_to_atom(Op ++ "_against_" ++ Mode ++ "_" ++ Data), inf, dpor}
+   || Op <- ["match", "match_object", "select", "select_delete"],
+      Mode <- ["matching", "different"],
+      Data <- ["keys", "tuples", "any", "matchspec"],
+
+      %% Only allow mutating ops against any!
+      %%
+      %% The only mutating ets op that would affect all keys is
+      %% give_away/2, which is not suitable for these tests
+      Data =/= "any" orelse Op =:= "select_delete"
+  ].
+
+%% match
+match_against_matching_keys() ->
+  test(match, ?match_even, delete, 2).
+
+match_against_matching_tuples() ->
+  test(match, ?match_even, insert, {20, 0}).
+
+match_against_matching_matchspec() ->
+  test(match, ?match_even, select_delete, ?select_even(true)).
+
+match_against_different_keys() ->
+  test(match, ?match_foo, delete, 2).
+
+match_against_different_tuples() ->
+  test(match, ?match_even, insert, {21, 1}).
+
+match_against_different_matchspec() ->
+  test(match, ?match_foo, select_delete, ?select_even(true)).
+
+%% match_object
+match_object_against_matching_keys() ->
+  test(match_object, ?match_even, delete, 2).
+
+match_object_against_matching_tuples() ->
+  test(match_object, ?match_even, insert, {20, 0}).
+
+match_object_against_matching_matchspec() ->
+  test(match_object, ?match_even, select_delete, ?select_even(true)).
+
+match_object_against_different_keys() ->
+  test(match_object, ?match_foo, delete, 2).
+
+match_object_against_different_tuples() ->
+  test(match_object, ?match_even, insert, {21, 1}).
+
+match_object_against_different_matchspec() ->
+  test(match_object, ?match_foo, select_delete, ?select_even(true)).
+
+%% select
+select_against_matching_keys() ->
+  test(select, ?select_even('$_'), delete, 2).
+
+select_against_matching_tuples() ->
+  test(select, ?select_even('$_'), insert, {20, 0}).
+
+select_against_matching_matchspec() ->
+  test(select, ?select_even('$_'), select_delete, ?select_even(true)).
+
+select_against_different_keys() ->
+  test(select, ?select_even('$_'), delete, foo).
+
+select_against_different_tuples() ->
+  test(select, ?select_even('$_'), insert, {21, 1}).
+
+select_against_different_matchspec() ->
+  test(select, ?select_even('$_'), select_delete, ?select_atom(true)).
+
+%% select_delete
+select_delete_against_matching_keys() ->
+  test(select_delete, ?select_even(true), lookup, 2).
+
+select_delete_against_matching_tuples() ->
+  %% Note: this may not be a perfect test case, as insert is also a
+  %% mutating op. So it may happen that Concuerror checks the insert
+  %% against the matchspec instead of the select_delete against the
+  %% tuples.
+  test(select_delete, ?select_even(true), insert, {20, 0}).
+
+select_delete_against_matching_any() ->
+  test(select_delete, ?select_even(true), next, 1).
+
+select_delete_against_matching_matchspec() ->
+  test(select_delete, ?select_even(true), match, ?match_even).
+
+select_delete_against_different_keys() ->
+  test(select_delete, ?select_even(true), lookup, foo).
+
+select_delete_against_different_tuples() ->
+  %% Note: this may not be a perfect test case, as insert is also a
+  %% mutating op. So it may happen that Concuerror checks the insert
+  %% against the matchspec instead of the select_delete against the
+  %% tuples.
+  test(select_delete, ?select_even(true), insert, {21, 1}).
+
+select_delete_against_different_any() ->
+  test(select_delete, ?select_even(true), next, 2).
+
+select_delete_against_different_matchspec() ->
+  test(select_delete, ?select_even(true), match, ?match_foo).
+
+%% generic test implementation
+test(Op1, Arg1, Op2, Arg2) ->
+  %% Prepare a table
+  T = ets:new(table, [public, ordered_set]),
+  ets:insert(T, [{N, N rem 2} || N <- lists:seq(1, 10)]),
+  ets:insert(T, [{foo, foo}, {bar, bar}, {baz, baz}]),
+
+  %% Perform the two operations in parallel
+  {Pid, Ref} = spawn_monitor(ets, Op1, [T, Arg1]),
+  apply(ets, Op2, [T, Arg2]),
+
+  %% Wait for the other operation to finish before destroying the table
+  receive {'DOWN', Ref, process, Pid, _} -> ok end,
+  receive after infinity -> ok end.


### PR DESCRIPTION
## Summary

An ets operation using a match spec (such as `match`, `select` or `select_delete`) depends only with ets operations modifying matching tuples, or with ets operations where the tuples are not known.

It would be possible to further improve the dependency tests between a match spec using ets operation and an operation where only the key is known by reducing the match spec to the key field only. But this is not yet implemented.

## Checklist

* [x] Has tests (or doesn't need them)
* [x] Too minor for CHANGELOG update
* [x] References related Issues
