### PR TITLE
Add option to report only the errors involving the first process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased](https://github.com/parapluu/Concuerror/tree/master)
 
 ### Added
+- `--first_process_errors_only` option
 - Parts of [aronisstav/erlang-concurrency-litmus-tests](https://github.com/aronisstav/erlang-concurrency-litmus-tests) as a testsuite
 - [Coveralls](https://coveralls.io/github/parapluu/Concuerror) code coverage tracking
 - [contributor's guide](./CONTRIBUTING.md)

--- a/src/concuerror.erl
+++ b/src/concuerror.erl
@@ -2,13 +2,23 @@
 
 -module(concuerror).
 
--export([run/1, maybe_cover_compile/0, maybe_cover_export/1]).
+%% Main entry point.
+-export([run/1]).
+
+%%------------------------------------------------------------------------------
+
+%% Internal export
+-export([maybe_cover_compile/0, maybe_cover_export/1]).
+
+%%------------------------------------------------------------------------------
 
 -export_type([exit_status/0]).
 
 -type exit_status() :: 'ok' | 'error' | 'fail'.
 
 -include("concuerror.hrl").
+
+%%------------------------------------------------------------------------------
 
 -spec run(concuerror_options:options()) -> exit_status().
 
@@ -21,6 +31,8 @@ run(RawOptions) ->
     end,
   maybe_cover_export(RawOptions),
   Status.
+
+%%------------------------------------------------------------------------------
 
 start(Options, LogMsgs) ->
   error_logger:tty(false),
@@ -44,6 +56,8 @@ start(Options, LogMsgs) ->
   ets:delete(Processes),
   ExitStatus.
 
+%%------------------------------------------------------------------------------
+
 -spec maybe_cover_compile() -> 'ok'.
 
 maybe_cover_compile() ->
@@ -59,6 +73,8 @@ maybe_cover_compile() ->
      true -> ok
   end.
 
+%%------------------------------------------------------------------------------
+
 -spec maybe_cover_export(term()) -> 'ok'.
 
 maybe_cover_export(Args) ->
@@ -70,6 +86,8 @@ maybe_cover_export(Args) ->
       ok;
      true -> ok
   end.
+
+%%------------------------------------------------------------------------------
 
 explain(Reason) ->
   try

--- a/src/concuerror.hrl
+++ b/src/concuerror.hrl
@@ -54,6 +54,7 @@
 -type assume_racing_opt() :: {boolean(), logger() | 'ignore'}.
 %%------------------------------------------------------------------------------
 -define(opt(A,O), proplists:get_value(A,O)).
+-define(opt(A,O,D), proplists:get_value(A,O,D)).
 %%------------------------------------------------------------------------------
 %% Logger verbosity
 -define(lquiet,    0).

--- a/src/concuerror_logger.erl
+++ b/src/concuerror_logger.erl
@@ -162,9 +162,6 @@ delete_props([Key|Rest], Proplist) ->
 -spec bound_reached(logger()) -> ok.
 
 bound_reached(Logger) ->
-  Msg = "Some interleavings were not considered due to schedule bounding.~n",
-  ?unique(Logger, ?lwarning, Msg, []),
-  ?debug(Logger, "OVER BOUND~n",[]),
   Logger ! bound_reached,
   ok.
 

--- a/src/concuerror_options.erl
+++ b/src/concuerror_options.erl
@@ -200,12 +200,12 @@ options() ->
     "Forces preemptions",
     "Whether Concuerror should enforce the scheduling strategy strictly or let"
     " a process run until blocked before reconsidering the scheduling policy."}
-  ,{keep_going, [basic, bug], $k, {boolean, false},
+  ,{keep_going, [basic, errors], $k, {boolean, false},
     "Keep running after an error is found",
     "Concuerror stops by default when the first error is found. Enable this"
     " flag to keep looking for more errors. Preferably, modify the test, or"
     " use the '--ignore_error' / '--treat_as_normal' options."}
-  ,{ignore_error, [bug], undefined, atom,
+  ,{ignore_error, [errors], undefined, atom,
     "Ignore particular kinds of errors",
     "Concuerror will not report errors of the specified kind:~n"
     "'abnormal_exit': processes exiting with any abnormal reason;"
@@ -214,14 +214,14 @@ options() ->
     "'abnormal_halt': processes executing erlang:halt/1,2 with status /= 0~n"
     "'deadlock': processes waiting at a receive statement~n"
     "'depth_bound': reaching the depth bound; check '-h depth_bound'"}
-  ,{treat_as_normal, [bug], undefined, atom,
-    "Exit reasons considered 'normal'",
+  ,{treat_as_normal, [errors], undefined, atom,
+    "Exit reasons treated as 'normal'",
     "A process that exits with the specified atom as reason (or with a reason"
     " that is a tuple with the specified atom as a first element) will not be"
     " reported as exiting abnormally. Useful e.g. when analyzing supervisors"
     " ('shutdown' is usually a normal exit reason in this case)."}
-  ,{assertions_only, [bug], undefined, {boolean, false},
-    "Only abnormal exits due to failed ?asserts are reported.",
+  ,{assertions_only, [errors], undefined, {boolean, false},
+    "Only report abnormal exits due to ?asserts",
     "Only processes that exit with a reason of form '{{assert*, _}, _}' are"
     " considered errors. Such exit reasons are generated e.g. by the"
     " stdlib/include/assert.hrl header file."}

--- a/src/concuerror_options.erl
+++ b/src/concuerror_options.erl
@@ -153,7 +153,7 @@ options() ->
     "                interleavings are reported as sleep-set blocked.~n"
     "- 'persistent': Using persistent sets. Do not use."}
   ,{optimal, [por], undefined, boolean,
-    "Deprecated. Use '--dpor (optimal | source)' instead.",
+    "Synonym for `--dpor optimal (true) | source (false)`.",
     nolong}
   ,{scheduling_bound_type, [bound, experimental], $c, {atom, none},
     "* Schedule bounding technique",
@@ -265,6 +265,8 @@ options() ->
 synonyms() ->
   [ {{observers, true}, {use_receive_patterns, true}}
   , {{observers, false}, {use_receive_patterns, false}}
+  , {{optimal, true}, {dpor, optimal}}
+  , {{optimal, false}, {dpor, source}}
   , {{ignore_error, crash}, {ignore_error, abnormal_exit}}
   ].
 
@@ -1077,12 +1079,6 @@ process_options(Options) ->
 process_options([], Acc) -> lists:reverse(Acc);
 process_options([{Key, Value} = Option|Rest], Acc) ->
   case Key of
-    optimal ->
-      "0.1" ++ [_|_] = ?VSN,
-      Msg =
-        "The option '--optimal' is deprecated."
-        " Use '--dpor (optimal | source)' instead.",
-      opt_error(Msg, [], dpor);
     MaybeInfinity
       when
         MaybeInfinity =:= interleaving_bound;

--- a/src/concuerror_options.erl
+++ b/src/concuerror_options.erl
@@ -206,7 +206,7 @@ options() ->
     " flag to keep looking for more errors. Preferably, modify the test, or"
     " use the '--ignore_error' / '--treat_as_normal' options."}
   ,{ignore_error, [bug], undefined, atom,
-    "Ignore particular kinds of errors (use -h ignore_error for more info)",
+    "Ignore particular kinds of errors",
     "Concuerror will not report errors of the specified kind:~n"
     "'abnormal_exit': processes exiting with any abnormal reason;"
     " check '-h treat_as_normal' and '-h assertions_only' for more refined"

--- a/src/concuerror_options.erl
+++ b/src/concuerror_options.erl
@@ -225,6 +225,9 @@ options() ->
     "Only processes that exit with a reason of form '{{assert*, _}, _}' are"
     " considered errors. Such exit reasons are generated e.g. by the"
     " stdlib/include/assert.hrl header file."}
+  ,{first_process_errors_only, [errors], undefined, {boolean, false},
+    "Only report errors that involve the first process",
+    "All errors involving only children processes will be ignored."}
   ,{timeout, [erlang, advanced], undefined, {integer, 5000},
     "How long to wait for an event (>= " ++
       integer_to_list(?MINIMUM_TIMEOUT) ++ "ms)",

--- a/src/concuerror_options.erl
+++ b/src/concuerror_options.erl
@@ -639,7 +639,7 @@ finalize_2(Options) ->
     , fun add_derived_defaults/1
     , fun add_getopt_defaults/1
     , fun group_multiples/1
-    , fun process_options/1
+    , fun fix_infinities/1
     , fun(O) ->
           add_defaults([{Opt, []} || Opt <- groupable()], false, O)
       end
@@ -1073,11 +1073,11 @@ group_multiples([{Key, Value} = Option|Rest], Acc) ->
 
 %%------------------------------------------------------------------------------
 
-process_options(Options) ->
-  process_options(Options, []).
+fix_infinities(Options) ->
+  fix_infinities(Options, []).
 
-process_options([], Acc) -> lists:reverse(Acc);
-process_options([{Key, Value} = Option|Rest], Acc) ->
+fix_infinities([], Acc) -> lists:reverse(Acc);
+fix_infinities([{Key, Value} = Option|Rest], Acc) ->
   case Key of
     MaybeInfinity
       when
@@ -1091,17 +1091,17 @@ process_options([{Key, Value} = Option|Rest], Acc) ->
         end,
       case Value of
         infinity ->
-          process_options(Rest, [Option|Acc]);
+          fix_infinities(Rest, [Option|Acc]);
         -1 ->
-          process_options(Rest, [{MaybeInfinity, infinity}|Acc]);
+          fix_infinities(Rest, [{MaybeInfinity, infinity}|Acc]);
         N when is_integer(N), N >= Limit ->
-          process_options(Rest, [Option|Acc]);
+          fix_infinities(Rest, [Option|Acc]);
         _Else ->
           Error = "The value of '--~s' must be -1 (infinity) or >= ~w",
           opt_error(Error, [Key, Limit], Key)
       end;
     _ ->
-      process_options(Rest, [Option|Acc])
+      fix_infinities(Rest, [Option|Acc])
   end.
 
 %%------------------------------------------------------------------------------

--- a/src/concuerror_scheduler.erl
+++ b/src/concuerror_scheduler.erl
@@ -136,6 +136,7 @@
           print_depth                  :: pos_integer(),
           processes                    :: processes(),
           receive_timeout_total        :: non_neg_integer(),
+          report_error                 :: [{interleaving_error_tag(), scope()}],
           scheduling                   :: concuerror_options:scheduling(),
           scheduling_bound_type        :: concuerror_options:scheduling_bound_type(),
           show_races                   :: boolean(),
@@ -198,6 +199,7 @@ run(Options) ->
        print_depth = ?opt(print_depth, Options),
        processes = Processes = ?opt(processes, Options),
        receive_timeout_total = 0,
+       report_error = [],
        scheduling = ?opt(scheduling, Options),
        scheduling_bound_type = SchedulingBoundType,
        show_races = ?opt(show_races, Options),
@@ -311,11 +313,13 @@ filter_errors(State) ->
   #scheduler_state{
      ignore_error = Ignored,
      interleaving_errors = UnfilteredErrors,
-     logger = Logger
+     logger = Logger,
+     report_error = Reported
     } = State,
   TaggedErrors = [{true, E} || E <- UnfilteredErrors],
   IgnoredErrors = update_all_tags(TaggedErrors, Ignored, false),
-  FinalErrors = [E || {true, E} <- IgnoredErrors],
+  ReportedErrors = update_all_tags(IgnoredErrors, Reported, true),
+  FinalErrors = [E || {true, E} <- ReportedErrors],
   case FinalErrors =/= UnfilteredErrors of
     true ->
       UniqueMsg = "Some errors were ignored ('--ignore_error').~n",

--- a/tests-real/suites/options/option3-tests
+++ b/tests-real/suites/options/option3-tests
@@ -4,6 +4,18 @@
 
 print_blue "$0"
 
+testing "Only first process errors"
+concuerror_console -f src/other_deadlock.erl --first_process_errors_only
+good
+
+testing "Only first process errors with error"
+! concuerror_console -f src/first_and_other_deadlock.erl --first_process_errors_only
+good
+
+testing "Only first process errors with ignored error"
+concuerror_console -f src/first_and_other_deadlock.erl --ignore_error deadlock --first_process_errors_only
+good
+
 testing "Symbolic registered names Info"
 ! concuerror_console -f src/register.erl
 consolehas "Showing PIDs as \"<symbolic name(/last registered name)>\" ('-h symbolic_names')."

--- a/tests-real/suites/options/src/first_and_other_deadlock.erl
+++ b/tests-real/suites/options/src/first_and_other_deadlock.erl
@@ -1,0 +1,28 @@
+-module(first_and_other_deadlock).
+
+-export([test/0]).
+
+test() ->
+  CoinFlip =
+    fun(Fun) ->
+        fun() ->
+            Palm = self(),
+            spawn(fun() -> Palm ! coin end),
+            receive
+              coin -> Fun()
+            after
+              0 -> ok
+            end
+        end
+    end,
+  MessageWaiter =
+    fun() ->
+        receive
+          ok -> ok
+        end
+    end,
+  P = self(),
+  MaybeDeadlock = spawn(MessageWaiter),
+  CoinForNever = spawn(CoinFlip(fun() -> P ! ok end)),
+  CoinForMaybe = spawn(CoinFlip(fun() -> MaybeDeadlock ! ok end)),
+  MessageWaiter().

--- a/tests-real/suites/options/src/other_deadlock.erl
+++ b/tests-real/suites/options/src/other_deadlock.erl
@@ -1,0 +1,28 @@
+-module(other_deadlock).
+
+-export([test/0]).
+
+test() ->
+  CoinFlip =
+    fun(Fun) ->
+        fun() ->
+            Palm = self(),
+            spawn(fun() -> Palm ! coin end),
+            receive
+              coin -> Fun()
+            after
+              0 -> ok
+            end
+        end
+    end,
+  MessageWaiter =
+    fun() ->
+        receive
+          ok -> ok
+        end
+    end,
+  P = self(),
+  MaybeDeadlock = spawn(MessageWaiter),
+  CoinForNever = spawn(fun() -> P ! ok end),
+  CoinForMaybe = spawn(CoinFlip(fun() -> MaybeDeadlock ! ok end)),
+  MessageWaiter().


### PR DESCRIPTION
## Summary

Add option to report only the errors involving the first process.

## Checklist

* [x] Has tests (or doesn't need them)
* [x] Updates CHANGELOG