### PR TITLE
Fix race info printing

### DIFF
--- a/src/concuerror_dependencies.erl
+++ b/src/concuerror_dependencies.erl
@@ -703,6 +703,9 @@ keys_or_tuples(#builtin_event{mfargs = {_,Op,[_|Rest] = Args}}) ->
     {update_counter,3} -> {keys, [hd(Rest)]}
   end.
 
+from_insert(undefined, _, _) ->
+  %% If table is undefined the op crashed so not mutating
+  false;
 from_insert(Table, Insert, InsertNewOrDelete) ->
   KeyPos = ets:info(Table, keypos),
   InsertList = case is_list(Insert) of true -> Insert; false -> [Insert] end,

--- a/tests/suites/basic_tests/results/ets_unguarded-test-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/ets_unguarded-test-inf-optimal.txt
@@ -1,0 +1,475 @@
+Concuerror v0.18-218-gb80549 started at 18 Apr 2018 10:17:26
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_unguarded,test,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* At step 8 process <P.1> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.1>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.1>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+* At step 10 process <P.2> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.2>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.2>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+* At step 12 process <P.3> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.3>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.3>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P>: true = ets:delete(table)
+    (while exiting)
+   7: <P.1>: Exception badarg raised by: ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+   8: <P.1>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.1>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+   9: <P.2>: Exception badarg raised by: ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+  10: <P.2>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.2>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+  11: <P.3>: Exception badarg raised by: ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+  12: <P.3>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.3>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #3
+--------------------------------------------------------------------------------
+Errors found:
+* At step 12 process <P.3> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.3>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.3>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.1>: true = ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+   7: <P.1>: exits normally
+   8: <P.2>: true = ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+   9: <P.2>: exits normally
+  10: <P>: true = ets:delete(table)
+    (while exiting)
+  11: <P.3>: Exception badarg raised by: ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+  12: <P.3>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.3>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #4
+--------------------------------------------------------------------------------
+Errors found:
+* At step 12 process <P.2> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.2>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.2>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.1>: true = ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+   7: <P.1>: exits normally
+   8: <P.3>: true = ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+   9: <P.3>: exits normally
+  10: <P>: true = ets:delete(table)
+    (while exiting)
+  11: <P.2>: Exception badarg raised by: ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+  12: <P.2>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.2>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #6
+--------------------------------------------------------------------------------
+Errors found:
+* At step 10 process <P.2> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.2>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.2>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+* At step 12 process <P.3> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.3>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.3>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.1>: true = ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+   7: <P.1>: exits normally
+   8: <P>: true = ets:delete(table)
+    (while exiting)
+   9: <P.2>: Exception badarg raised by: ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+  10: <P.2>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.2>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+  11: <P.3>: Exception badarg raised by: ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+  12: <P.3>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.3>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #7
+--------------------------------------------------------------------------------
+Errors found:
+* At step 12 process <P.1> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.1>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.1>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: true = ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+   7: <P.2>: exits normally
+   8: <P.3>: true = ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+   9: <P.3>: exits normally
+  10: <P>: true = ets:delete(table)
+    (while exiting)
+  11: <P.1>: Exception badarg raised by: ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+  12: <P.1>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.1>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #9
+--------------------------------------------------------------------------------
+Errors found:
+* At step 10 process <P.1> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.1>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.1>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+* At step 12 process <P.3> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.3>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.3>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: true = ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+   7: <P.2>: exits normally
+   8: <P>: true = ets:delete(table)
+    (while exiting)
+   9: <P.1>: Exception badarg raised by: ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+  10: <P.1>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.1>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+  11: <P.3>: Exception badarg raised by: ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+  12: <P.3>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.3>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #11
+--------------------------------------------------------------------------------
+Errors found:
+* At step 12 process <P.3> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.3>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.3>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: true = ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+   7: <P.2>: exits normally
+   8: <P.1>: true = ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+   9: <P.1>: exits normally
+  10: <P>: true = ets:delete(table)
+    (while exiting)
+  11: <P.3>: Exception badarg raised by: ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+  12: <P.3>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.3>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #12
+--------------------------------------------------------------------------------
+Errors found:
+* At step 10 process <P.1> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.1>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.1>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+* At step 12 process <P.2> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.2>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.2>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.3>: true = ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+   7: <P.3>: exits normally
+   8: <P>: true = ets:delete(table)
+    (while exiting)
+   9: <P.1>: Exception badarg raised by: ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+  10: <P.1>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.1>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+  11: <P.2>: Exception badarg raised by: ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+  12: <P.2>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.2>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #14
+--------------------------------------------------------------------------------
+Errors found:
+* At step 12 process <P.2> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.2>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.2>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.3>: true = ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+   7: <P.3>: exits normally
+   8: <P.1>: true = ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+   9: <P.1>: exits normally
+  10: <P>: true = ets:delete(table)
+    (while exiting)
+  11: <P.2>: Exception badarg raised by: ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+  12: <P.2>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.2>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Interleaving #15
+--------------------------------------------------------------------------------
+Errors found:
+* At step 12 process <P.1> exited abnormally
+    Reason:
+      {badarg,[{ets,insert,
+                    [table,{1,<P.1>}],
+                    [17,
+                     {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]}
+    Stacktrace:
+      [{ets,insert,
+            [table,{1,<P.1>}],
+            [17,
+             {file,"/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_unguarded.erl"}]}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: table = ets:new(table, [named_table,public])
+    in ets_unguarded.erl line 14
+   2: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<ets_unguarded.0.92061103>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.3>: true = ets:insert(table, {1,<P.3>})
+    in ets_unguarded.erl line 17
+   7: <P.3>: exits normally
+   8: <P.2>: true = ets:insert(table, {1,<P.2>})
+    in ets_unguarded.erl line 17
+   9: <P.2>: exits normally
+  10: <P>: true = ets:delete(table)
+    (while exiting)
+  11: <P.1>: Exception badarg raised by: ets:insert(table, {1,<P.1>})
+    in ets_unguarded.erl line 17
+  12: <P.1>: exits abnormally ({badarg,[{ets,insert,[table,{1,<P.1>}],[17,{file,[47,85,115,101,114,115,47,115|...]}]}]})
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check '--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_unguarded
+* Automatically instrumented module lists
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+* You can see pairs of racing instructions (in the report and '--graph') with '--show_races true'
+
+################################################################################
+Done at 18 Apr 2018 10:17:27 (Exit status: error)
+  Summary: 10 errors, 16/16 interleavings explored

--- a/tests/suites/basic_tests/src/ets_unguarded.erl
+++ b/tests/suites/basic_tests/src/ets_unguarded.erl
@@ -1,0 +1,19 @@
+-module(ets_unguarded).
+
+-export([test/0]).
+
+-export([scenarios/0]).
+
+%%------------------------------------------------------------------------------
+
+scenarios() -> [{test, inf, optimal}].
+
+%%------------------------------------------------------------------------------
+
+test() ->
+  ets:new(table, [named_table, public]),
+  Fun =
+    fun() ->
+        ets:insert(table, {1, self()})
+    end,
+  _ = [spawn(Fun) || _ <- lists:seq(1, 3)].


### PR DESCRIPTION
## Summary

Race info printing was messed up when the order of printing error traces and race analysis was changed. This fixes the shown info.

A small bug in the dependencies of ETS insert is also fixed.

## Checklist

* [ ] Has tests (or doesn't need them)
