### PR TITLE
Add support for new BIF ets:internal_select_delete/2

### DIFF
--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -1007,6 +1007,7 @@ run_built_in(ets, F, N, [Name|Args], Info)
     ;{F,N} =:= {select, 2}
     ;{F,N} =:= {select, 3}
     ;{F,N} =:= {select_delete, 2}
+    ;{F,N} =:= {internal_select_delete, 2}
     ;{F,N} =:= {update_counter, 3}
     ->
   {Tid, System} = check_ets_access_rights(Name, {F,N}, Info),
@@ -1771,6 +1772,7 @@ ets_ops_access_rights_map(Op) ->
     {next          ,_} -> read;
     {select        ,_} -> read;
     {select_delete ,_} -> write;
+    {internal_select_delete ,_} -> write;
     {update_counter,3} -> write
   end.
 


### PR DESCRIPTION
While at it, simplify some specs by using a type.

## Summary

Makes the test suite also pass when using the upcoming Erlang/OTP 21.0