### PR TITLE
Fix ETS TIDs in OTP 20

### DIFF
--- a/src/concuerror.hrl
+++ b/src/concuerror.hrl
@@ -128,10 +128,10 @@
 -type ets_tables() :: ets:tid().
 
 -define(ets_name_none, 0).
--define(new_ets_table(Tid, Protection),
-        {Tid, unknown, unknown, Protection, unknown, true}).
--define(new_system_ets_table(Tid, Protect),
-        {Tid, Tid, self(), Protect, unknown, true}).
+-define(ets_table_entry(Tid, Name, Owner, Protection, Heir),
+        {Tid, Name, Owner, Protection, Heir, true}).
+-define(system_ets_table_entry(Tid, Protection),
+        ?ets_table_entry(Tid, Tid, self(), Protection, unknown)).
 -define(ets_name, 2).
 -define(ets_owner, 3).
 -define(ets_protection, 4).

--- a/tests/suites/basic_tests/results/ets_info-info_bad-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/ets_info-info_bad-inf-optimal.txt
@@ -1,0 +1,47 @@
+Concuerror v0.19+build.2049.ref9e3b1de started at 19 Jun 2018 16:07:31
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_info,info_bad,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_info.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check '--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/ets_info-info_bad-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_info
+
+################################################################################
+Done at 19 Jun 2018 16:07:31 (Exit status: ok)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/ets_info-info_badarg-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/ets_info-info_badarg-inf-optimal.txt
@@ -1,0 +1,47 @@
+Concuerror v0.19+build.2049.ref8b1d7cb started at 19 Jun 2018 16:10:35
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_info,info_badarg,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_info.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check '--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/ets_info-info_badarg-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_info
+
+################################################################################
+Done at 19 Jun 2018 16:10:35 (Exit status: ok)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/ets_info-info_good-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/ets_info-info_good-inf-optimal.txt
@@ -1,0 +1,47 @@
+Concuerror v0.19+build.2049.ref9e3b1de started at 19 Jun 2018 16:07:31
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_info,info_good,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_info.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check '--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/ets_info-info_good-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_info
+
+################################################################################
+Done at 19 Jun 2018 16:07:31 (Exit status: ok)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/results/ets_info-info_system-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/ets_info-info_system-inf-optimal.txt
@@ -1,0 +1,47 @@
+Concuerror v0.19+build.2049.ref9e3b1de started at 19 Jun 2018 16:07:31
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{ets_info,info_system,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/ets_info.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check '--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/ets_info-info_system-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module ets_info
+
+################################################################################
+Done at 19 Jun 2018 16:07:31 (Exit status: ok)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/src/ets_info.erl
+++ b/tests/suites/basic_tests/src/ets_info.erl
@@ -1,0 +1,31 @@
+-module(ets_info).
+
+-compile(export_all).
+
+scenarios() ->
+  [ info_good
+  , info_bad
+  , info_system
+  , info_badarg
+  ].
+
+info_badarg() ->
+  try
+    ets:info(1.0),
+    exit(fail)
+  catch
+    error:badarg ->
+      ok
+  end.
+
+info_system() ->
+  true = undefined =/= ets:info(global_names).
+
+info_bad() ->
+  T = ets:new(foo, []),
+  ets:delete(T),
+  true = undefined =:= ets:info(T).
+
+info_good() ->
+  T = ets:new(foo, []),
+  true = undefined =/= ets:info(T).


### PR DESCRIPTION
## Summary

In OTP 20 ETS identifiers changed to references.

## Checklist

* [x] Has tests