### PR TITLE
Fix coverage

### DIFF
--- a/.travis/after_success
+++ b/.travis/after_success
@@ -4,11 +4,12 @@
 
 if [ "$COLLECT_COVERAGE" = "true" ]; then
   echo "Generate coverage report..."
+  EBIN=$(rebar3 path --ebin --app concuerror)
   cd cover
   export COVER_COMBINE=all.coverdata
   mv *.coverdata data || true
   ./cover-report data || true
-  covertool/covertool -cover $COVER_COMBINE -src ../src -appname concuerror
+  covertool/covertool -cover $COVER_COMBINE -ebin $EBIN -appname concuerror
   bash <(curl -s https://codecov.io/bash) -c -F "$FLAG"
   echo "Report sent!"
 fi

--- a/.travis/before_script
+++ b/.travis/before_script
@@ -6,7 +6,7 @@ if [ "$COLLECT_COVERAGE" = "true" ]; then
   echo "Prepare to collect coverage data."
   make cover/data
   cd cover
-  git clone https://github.com/idubrov/covertool.git
+  git clone https://github.com/concuerror/covertool.git --branch 0.0.0-concuerror1
   cd covertool
   make compile
   echo "Ready to collect coverage data!"


### PR DESCRIPTION
## Summary

Due to recent changes in covertool, coverage reports stopped being generated. This PR fixes this and locks a working version so that this doesn't break again unexpectedly.