### PR TITLE
Fix stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
-
+- fixed stacktrace information (#276)
 
 ## [0.20](https://github.com/parapluu/Concuerror/releases/tag/0.20) - 2018-07-15
 

--- a/tests-real/suites/options/header
+++ b/tests-real/suites/options/header
@@ -42,12 +42,19 @@ function mygrepconsole {
     grep_this $Console $@
 }
 
+function nogrep {
+    File=$1
+    Target=$2
+    testing "... and $1 does not have \"$Target\""
+    grep -q "$Target" $Out
+    [ $? -eq 1 ]
+}
+
 function grep_this {
     File=$1
     shift
     grep -q "$1" $File
-    Ret=$?
-    if [ $Ret -eq 0 ]; then
+    if [ $? -eq 0 ]; then
        return 0
     else
        exit 1

--- a/tests-real/suites/output/output-tests
+++ b/tests-real/suites/output/output-tests
@@ -46,13 +46,9 @@ $CONCUERROR -f src/many_scheds.erl -t test_large -v1 -b 6 2>&1 | tr '\033' '#' |
 has_basic_progress
 
 testing "No tip for harmless exit signals"
-! concuerror_console -f src/harmless_exit.erl -k
+concuerror_console_error -f src/harmless_exit.erl -k
 print_ok
-Target="An abnormal exit signal"
-testing "... and output does not have \"$Target\""
-if grep -q "$Target" $Out; then
-    exit 1
-fi
+nogrep $Out "An abnormal exit signal"
 good
 
 testing "Graph format"
@@ -66,39 +62,35 @@ good
 testing "Correct race info"
 concuerror_console -f src/race_info.erl --show_races
 print_ok
-Target="Interleaving #2"
-testing "... and output does not have \"$Target\""
-if grep -q "$Target" $Out; then
-    exit 1
-fi
+nogrep $Out "Interleaving #2"
 outputhas "New races found"
 
 testing "Basic message is produced for error detection"
-! concuerror_console -f src/buggy.erl
+concuerror_console_error -f src/buggy.erl
 consolehas "Errors were found! (check concuerror_report.txt)"
 
 testing "Deadlock shows messages"
-! concuerror_console -f src/deadlock.erl
+concuerror_console_error -f src/deadlock.erl
 outputhas "Mailbox contents: \[foo\]"
 
 testing "Funs are pretty"
-! concuerror_console -f src/a_fun.erl
+concuerror_console_error -f src/a_fun.erl
 outputhas "#Fun<a_fun.0"
 
 testing "Symbolic registered names Info"
-! concuerror_console -f src/register.erl
+concuerror_console_error -f src/register.erl
 consolehas "Showing PIDs as \"<symbolic name(/last registered name)>\" ('-h symbolic_names')."
 
 testing "Symbolic registered names error info"
-! concuerror_console -f src/register.erl
+concuerror_console_error -f src/register.erl
 outputhas "process <P.1/foo> exited abnormally"
 
 testing "Decent stacktrace report"
-! concuerror_console -f src/stacktrace.erl
+concuerror_console_error -f src/stacktrace.erl
 outputhas "[{file,\"src/stacktrace.erl\"},{line,93}]"
 
 testing "Yet another decent stacktrace report"
-! concuerror_console -f src/more_stacktrace.erl
+concuerror_console_error -f src/more_stacktrace.erl
 outputhas "[6,{file,\"src/more_stacktrace.erl\"}]"
 
 . footer

--- a/tests-real/suites/output/output-tests
+++ b/tests-real/suites/output/output-tests
@@ -93,4 +93,10 @@ testing "Yet another decent stacktrace report"
 concuerror_console_error -f src/more_stacktrace.erl
 outputhas "[6,{file,\"src/more_stacktrace.erl\"}]"
 
+testing "Do not blame the innocent stacktrace"
+concuerror_console_error -f src/more_stacktrace.erl -t do_not_blame_me
+print_ok
+nogrep $Out "{erlang,'!',"
+good
+
 . footer

--- a/tests-real/suites/output/src/more_stacktrace.erl
+++ b/tests-real/suites/output/src/more_stacktrace.erl
@@ -1,6 +1,10 @@
 -module(more_stacktrace).
 
--export([test/0]).
+-export([test/0, do_not_blame_me/0]).
 
 test() ->
   erlang:diplay().
+
+do_not_blame_me() ->
+  self() ! ok,
+  exit(abnormal).


### PR DESCRIPTION
## Summary
The patch c95c2c6 made it possible for stacktraces to linger and be reported when they were irrelevant. This patch fixes this.

Fixes aronisstav/Concuerror#42.

## Checklist

* [x] Has tests (or doesn't need them)
* [x] Updates CHANGELOG (or too minor)
* [x] References related Issues
