### PR TITLE
Fix dependencies of process_info(..., message*)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - handling of demonitors (#281)
+- handling of process_info(..., messages) (#283)
 
 ### Fixed
 - fixed stacktrace information (#276)

--- a/src/concuerror.erl
+++ b/src/concuerror.erl
@@ -176,8 +176,9 @@ start(Options, LogMsgs) ->
 
 maybe_cover_compile() ->
   Cover = os:getenv("CONCUERROR_COVER"),
-  case Cover =/= false of
+  case get(concuerror_cover) =:= undefined andalso Cover =/= false of
     true ->
+      put(concuerror_cover, Cover),
       case cover:is_compiled(?MODULE) of
         false ->
           {ok, Modules} = application:get_key(concuerror, modules),
@@ -191,8 +192,8 @@ maybe_cover_compile() ->
 %%------------------------------------------------------------------------------
 
 maybe_cover_export(Args) ->
-  Cover = os:getenv("CONCUERROR_COVER"),
-  case Cover =/= false of
+  Cover = erase(concuerror_cover),
+  case Cover =/= undefined of
     true ->
       Hash = binary:decode_unsigned(erlang:md5(term_to_binary(Args))),
       Out = filename:join([Cover, io_lib:format("~.16b", [Hash])]),

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -311,15 +311,11 @@ built_in(erlang, Display, 1, [Term], _Location, Info)
     end,
   concuerror_logger:print(Info#concuerror_info.logger, standard_io, Chars),
   {{didit, true}, Info};
-%% Process dictionary has been restored here. No need to report such ops.
+%% Inner process dictionary has been restored here. No need to report such ops.
+%% Also can't fail, as only true builtins reach this code.
 built_in(erlang, Name, _Arity, Args, _Location, Info)
   when Name =:= get; Name =:= get_keys; Name =:= put; Name =:= erase ->
-  try
-    {{didit, erlang:apply(erlang, Name, Args)}, Info}
-  catch
-    error:Reason -> {{error, Reason}, Info}
-  end;
-%% XXX: Temporary
+  {{didit, erlang:apply(erlang, Name, Args)}, Info};
 built_in(erlang, hibernate, 3, Args, _Location, Info) ->
   [Module, Name, HibArgs] = Args,
   self() ! {start, Module, Name, HibArgs},

--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -678,8 +678,13 @@ run_built_in(erlang, process_info, 2, [Pid, Item], Info) when is_atom(Item) ->
             catch error:badarg -> []
             end;
           messages ->
-            #concuerror_info{message_queue = Queue} = TheirInfo,
-            [M || #message{data = M} <- queue:to_list(Queue)];
+            #concuerror_info{logger = Logger} = TheirInfo,
+            Msg =
+              "Concuerror does not properly support"
+              " erlang:process_info(Other, messages),"
+              " returning an empty list instead.~n",
+            ?unique(Logger, ?lwarning, Msg, []),
+            [];
           message_queue_len ->
             #concuerror_info{message_queue = Queue} = TheirInfo,
             queue:len(Queue);

--- a/src/concuerror_instrumenter.erl
+++ b/src/concuerror_instrumenter.erl
@@ -179,6 +179,8 @@ is_unsafe({erlang, F, A}) ->
       StringF = atom_to_list(F),
       not erl_safe(StringF)
   end;
+is_unsafe({erts_internal, garbage_collect, _}) ->
+  false;
 is_unsafe({Safe, _, _})
   when
     Safe =:= binary
@@ -230,7 +232,6 @@ erl_safe("fun_info"              ++ _) -> true;
 erl_safe("function_exported"         ) -> true;
 erl_safe("garbage_collect"           ) -> true;
 erl_safe("get_module_info"           ) -> true;
-erl_safe("hash"                      ) -> true;
 erl_safe("hibernate"                 ) -> false; %% Must be instrumented.
 erl_safe("insert_element"            ) -> true;
 erl_safe("iolist_size"               ) -> true;

--- a/tests/suites/basic_tests/results/process_info-test_message_queue_len-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/process_info-test_message_queue_len-inf-dpor.txt
@@ -1,0 +1,485 @@
+Concuerror AFS2018+build.2177.ref65f5340 started at 21 Aug 2018 12:15:41
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{process_info,test_message_queue_len,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/process_info.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.3>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+   8: <P.2>: exits normally
+   9: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  10: <P.3>: exits normally
+  11: <P.4>: [{message_queue_len,3}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  12: <P.4>: exits normally
+  13: <P.1>: receives message ({ok,<P.2>})
+    in process_info.erl line 40
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.3>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+   8: <P.2>: exits normally
+   9: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  10: <P.3>: exits normally
+  11: <P.1>: receives message ({ok,<P.2>})
+    in process_info.erl line 40
+  12: <P.4>: [{message_queue_len,2}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  13: <P.4>: exits normally
+################################################################################
+Interleaving #3
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.3>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+   8: <P.2>: exits normally
+   9: <P.4>: [{message_queue_len,2}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  10: <P.4>: exits normally
+  11: <P.1>: receives message ({ok,<P.2>})
+    in process_info.erl line 40
+  12: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  13: <P.3>: exits normally
+################################################################################
+Interleaving #4
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.3>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+   8: <P.2>: exits normally
+   9: <P.1>: receives message ({ok,<P.2>})
+    in process_info.erl line 40
+  10: <P.4>: [{message_queue_len,1}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  11: <P.4>: exits normally
+  12: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  13: <P.3>: exits normally
+################################################################################
+Interleaving #5
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+   8: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+   9: <P.2>: exits normally
+  10: <P.3>: exits normally
+  11: <P.4>: [{message_queue_len,3}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  12: <P.4>: exits normally
+  13: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+################################################################################
+Interleaving #6
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+   8: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+   9: <P.2>: exits normally
+  10: <P.3>: exits normally
+  11: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+  12: <P.4>: [{message_queue_len,2}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  13: <P.4>: exits normally
+################################################################################
+Interleaving #7
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+   8: <P.3>: exits normally
+   9: <P.4>: [{message_queue_len,2}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  10: <P.4>: exits normally
+  11: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+  12: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  13: <P.2>: exits normally
+################################################################################
+Interleaving #8
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+   8: <P.3>: exits normally
+   9: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+  10: <P.4>: [{message_queue_len,1}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  11: <P.4>: exits normally
+  12: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  13: <P.2>: exits normally
+################################################################################
+Interleaving #9
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.3>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.4>: [{message_queue_len,1}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+   8: <P.4>: exits normally
+   9: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  10: <P.2>: exits normally
+  11: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  12: <P.3>: exits normally
+  13: <P.1>: receives message ({ok,<P.2>})
+    in process_info.erl line 40
+################################################################################
+Interleaving #10
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.4>: [{message_queue_len,1}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+   8: <P.4>: exits normally
+   9: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  10: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  11: <P.2>: exits normally
+  12: <P.3>: exits normally
+  13: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+################################################################################
+Interleaving #11
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+   7: <P.3>: exits normally
+   8: <P.4>: [{message_queue_len,1}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+   9: <P.4>: exits normally
+  10: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+  11: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+  12: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  13: <P.2>: exits normally
+################################################################################
+Interleaving #12
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+   7: <P.3>: exits normally
+   8: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+   9: <P.4>: [{message_queue_len,0}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+  10: <P.4>: exits normally
+  11: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+  12: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  13: <P.2>: exits normally
+################################################################################
+Interleaving #13
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.3>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.4>: [{message_queue_len,0}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+   7: <P.4>: exits normally
+   8: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   9: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  10: <P.2>: exits normally
+  11: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  12: <P.3>: exits normally
+  13: <P.1>: receives message ({ok,<P.2>})
+    in process_info.erl line 40
+################################################################################
+Interleaving #14
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.4>: [{message_queue_len,0}] = erlang:process_info(<P.1>, [message_queue_len])
+    in process_info.erl line 57
+   7: <P.4>: exits normally
+   8: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   9: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  10: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  11: <P.2>: exits normally
+  12: <P.3>: exits normally
+  13: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+################################################################################
+Exploration completed!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check `--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+* Each of the first 10 interleavings explored so far had some error. This can make later debugging difficult, as the generated report will include too much info. Consider refactoring your code, or using the appropriate options to filter out irrelevant errors.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/process_info-test_message_queue_len-inf-dpor.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module process_info
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+* You can see pairs of racing instructions (in the report and '--graph') with '--show_races true'
+
+################################################################################
+Done at 21 Aug 2018 12:15:41 (Exit status: error)
+  Summary: 14 errors, 14/14 interleavings explored

--- a/tests/suites/basic_tests/results/process_info-test_messages-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/process_info-test_messages-inf-dpor.txt
@@ -1,0 +1,117 @@
+Concuerror AFS2018+build.2177.ref65f5340 started at 21 Aug 2018 12:15:37
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{process_info,test_messages,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/process_info.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.3>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+   8: <P.2>: exits normally
+   9: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  10: <P.3>: exits normally
+  11: <P.4>: [{messages,[]}] = erlang:process_info(<P.1>, [messages])
+    in process_info.erl line 57
+  12: <P.4>: exits normally
+  13: <P.1>: receives message ({ok,<P.2>})
+    in process_info.erl line 40
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 41
+     Mailbox contents: [{bar,<P.2>},{ok,<P.2>}]
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-0-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: <P.3> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   4: <P>: <P.4> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_with_messages/1-fun-3-'.0>,[]])
+    in erlang.erl line 2687
+   5: <P>: exits normally
+   6: <P.2>: {bar,<P.2>} = <P.1> ! {bar,<P.2>}
+    in process_info.erl line 46
+   7: <P.4>: [{messages,[]}] = erlang:process_info(<P.1>, [messages])
+    in process_info.erl line 57
+   8: <P.4>: exits normally
+   9: <P.3>: {ok,<P.3>} = <P.1> ! {ok,<P.3>}
+    in process_info.erl line 51
+  10: <P.2>: {ok,<P.2>} = <P.1> ! {ok,<P.2>}
+    in process_info.erl line 47
+  11: <P.2>: exits normally
+  12: <P.3>: exits normally
+  13: <P.1>: receives message ({ok,<P.3>})
+    in process_info.erl line 40
+################################################################################
+Exploration completed!
+################################################################################
+Warnings:
+--------------------------------------------------------------------------------
+* Concuerror does not properly support erlang:process_info(Other, messages), returning an empty list instead.
+
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check `--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/process_info-test_messages-inf-dpor.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module process_info
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+* You can see pairs of racing instructions (in the report and '--graph') with '--show_races true'
+
+################################################################################
+Done at 21 Aug 2018 12:15:37 (Exit status: error)
+  Summary: 2 errors, 2/2 interleavings explored

--- a/tests/suites/basic_tests/results/process_info-test_mql_flush-inf-dpor.txt
+++ b/tests/suites/basic_tests/results/process_info-test_mql_flush-inf-dpor.txt
@@ -1,0 +1,151 @@
+Concuerror AFS2018+build.2178.ref4861cf2 started at 21 Aug 2018 13:56:25
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{process_info,test_mql_flush,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/process_info.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Interleaving #1
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 67
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: exits normally
+   4: <P.1>: {<P.1.1>,#Ref<0.4212114868.2148532225.166955>} = erlang:spawn_opt({erlang,apply,[#Fun<process_info.'-test_mql_flush/0-fun-0-'.0>,[]],[monitor]})
+    in erlang.erl line 2731
+   5: <P.1>: true = erlang:demonitor(#Ref<0.4212114868.2148532225.166955>, [flush])
+    in process_info.erl line 66
+   6: <P.2>: {message_queue_len,0} = erlang:process_info(<P.1>, message_queue_len)
+    in process_info.erl line 72
+   7: <P.2>: exits normally
+   8: <P.1.1>: exits normally
+   9: <P.1.1>: {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal} = erlang:send(<P.1>, {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal})
+    (while exiting)
+################################################################################
+Interleaving #2
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 67
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: exits normally
+   4: <P.1>: {<P.1.1>,#Ref<0.4212114868.2148532225.166955>} = erlang:spawn_opt({erlang,apply,[#Fun<process_info.'-test_mql_flush/0-fun-0-'.0>,[]],[monitor]})
+    in erlang.erl line 2731
+   5: <P.1>: true = erlang:demonitor(#Ref<0.4212114868.2148532225.166955>, [flush])
+    in process_info.erl line 66
+   6: <P.1.1>: exits normally
+   7: <P.1.1>: {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal} = erlang:send(<P.1>, {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal})
+    (while exiting)
+   8: <P.2>: {message_queue_len,0} = erlang:process_info(<P.1>, message_queue_len)
+    in process_info.erl line 72
+   9: <P.2>: exits normally
+################################################################################
+Interleaving #3
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 67
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: exits normally
+   4: <P.1>: {<P.1.1>,#Ref<0.4212114868.2148532225.166955>} = erlang:spawn_opt({erlang,apply,[#Fun<process_info.'-test_mql_flush/0-fun-0-'.0>,[]],[monitor]})
+    in erlang.erl line 2731
+   5: <P.1.1>: exits normally
+   6: <P.2>: {message_queue_len,0} = erlang:process_info(<P.1>, message_queue_len)
+    in process_info.erl line 72
+   7: <P.2>: exits normally
+   8: <P.1.1>: {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal} = erlang:send(<P.1>, {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal})
+    (while exiting)
+   9: <P.1>: true = erlang:demonitor(#Ref<0.4212114868.2148532225.166955>, [flush])
+    in process_info.erl line 66
+################################################################################
+Interleaving #4
+--------------------------------------------------------------------------------
+Errors found:
+* Blocked at a 'receive' ("deadlocked"; other processes have exited):
+    <P.1> in process_info.erl line 67
+     Mailbox contents: []
+--------------------------------------------------------------------------------
+Event trace:
+   1: <P>: <P.1> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-1-'.0>,[]])
+    in erlang.erl line 2687
+   2: <P>: <P.2> = erlang:spawn(erlang, apply, [#Fun<process_info.'-test_mql_flush/0-fun-2-'.0>,[]])
+    in erlang.erl line 2687
+   3: <P>: exits normally
+   4: <P.1>: {<P.1.1>,#Ref<0.4212114868.2148532225.166955>} = erlang:spawn_opt({erlang,apply,[#Fun<process_info.'-test_mql_flush/0-fun-0-'.0>,[]],[monitor]})
+    in erlang.erl line 2731
+   5: <P.1.1>: exits normally
+   6: <P.1.1>: {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal} = erlang:send(<P.1>, {'DOWN',#Ref<0.4212114868.2148532225.166955>,process,<P.1.1>,normal})
+    (while exiting)
+   7: <P.2>: {message_queue_len,1} = erlang:process_info(<P.1>, message_queue_len)
+    in process_info.erl line 72
+   8: <P.2>: exits normally
+   9: <P.1>: true = erlang:demonitor(#Ref<0.4212114868.2148532225.166955>, [flush])
+    in process_info.erl line 66
+################################################################################
+Exploration completed!
+################################################################################
+Warnings:
+--------------------------------------------------------------------------------
+* Concuerror may let exiting processes emit 'DOWN' messages for cancelled monitors. Any such messages are discarded upon delivery and can never be received.
+
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check `--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+* Increase '--print_depth' if output/graph contains "...".
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/process_info-test_mql_flush-inf-dpor.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module process_info
+* Automatically instrumented module erlang
+* Continuing after error (-k)
+* You can see pairs of racing instructions (in the report and '--graph') with '--show_races true'
+
+################################################################################
+Done at 21 Aug 2018 13:56:26 (Exit status: error)
+  Summary: 4 errors, 4/4 interleavings explored

--- a/tests/suites/basic_tests/results/safeops_coverage-test-inf-optimal.txt
+++ b/tests/suites/basic_tests/results/safeops_coverage-test-inf-optimal.txt
@@ -1,0 +1,48 @@
+Concuerror AFS2018+build.2175.reff4adefa started at 21 Aug 2018 10:17:50
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{safeops_coverage,test,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/basic_tests/src/safeops_coverage.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check `--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/basic_tests/results/safeops_coverage-test-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module safeops_coverage
+* Automatically instrumented module erlang
+
+################################################################################
+Done at 21 Aug 2018 10:17:50 (Exit status: ok)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/basic_tests/src/process_info.erl
+++ b/tests/suites/basic_tests/src/process_info.erl
@@ -1,9 +1,16 @@
 -module(process_info).
 
 -compile(export_all).
--export([scenarios/0]).
 
-scenarios() -> [{T, inf, dpor} || T <- [test1, test2, test3]].
+scenarios() ->
+  [{T, inf, dpor} ||
+    T <- [ test1
+         , test2
+         , test3
+         , test_messages
+         , test_message_queue_len
+         , test_mql_flush
+         ]].
 
 test1() ->
     Fun = fun() -> register(foo, self()) end,
@@ -21,3 +28,47 @@ test3() ->
     _ -> ok
   end,
   undefined = process_info(P, [registered_name, group_leader]).
+
+test_messages() ->
+  test_with_messages([messages]).
+
+test_message_queue_len() ->
+  test_with_messages([message_queue_len]).
+
+test_with_messages(Info) ->
+  Fun =
+    fun() ->
+        receive {ok, _} -> ok end,
+        receive after infinity -> ok end
+    end,
+  P = spawn(Fun),
+  Fun2 =
+    fun() ->
+        P ! {bar, self()},
+        P ! {ok, self()}
+    end,
+  Fun3 =
+    fun() ->
+        P ! {ok, self()}
+    end,
+  spawn(Fun2),
+  spawn(Fun3),
+  Fun4 =
+    fun() ->
+        process_info(P, Info)
+    end,
+  spawn(Fun4).
+
+test_mql_flush() ->
+  Fun =
+    fun() ->
+        {P, M} = spawn_monitor(fun() -> ok end),
+        demonitor(M, [flush]),
+        receive after infinity -> ok end
+    end,
+  P = spawn(Fun),
+  Fun2 =
+    fun() ->
+        process_info(P, message_queue_len)
+    end,
+  spawn(Fun2).

--- a/tests/suites/basic_tests/src/safeops_coverage.erl
+++ b/tests/suites/basic_tests/src/safeops_coverage.erl
@@ -1,0 +1,21 @@
+-module(safeops_coverage).
+
+-compile(export_all).
+
+scenarios() ->
+  [ test
+  ].
+
+test() ->
+  erlang:adler32("42"),
+  [1, 2, 3, 4] = erlang:append([1, 2], [3, 4]),
+  erlang:bump_reductions(10),
+  erlang:crc32("42"),
+  erlang:decode_packet(raw, <<"foo">>, []),
+  {c} = erlang:delete_element(1, {b, c}),
+  erlang:external_size(42),
+  erlang:garbage_collect(),
+  {b, c} = erlang:insert_element(1, {c}, b),
+  true = erlang:is_builtin(erlang, is_builtin, 3),
+  {a, a, a} = erlang:make_tuple(3, a),
+  [1, 2] = erlang:subtract([1, 2, 3], [3]).


### PR DESCRIPTION
## Summary

More accurate dependencies of message queue info ops, but some degradation as the `message` item should normally be an observer of message delivery races. As this is too complex right now, it was degraded instead.

## Checklist

* [x] Has tests
* [x] Updates CHANGELOG
