### PR TITLE
Add erts_internal:maps_next/3 to safe functions

### DIFF
--- a/src/concuerror_instrumenter.erl
+++ b/src/concuerror_instrumenter.erl
@@ -181,6 +181,8 @@ is_unsafe({erlang, F, A}) ->
   end;
 is_unsafe({erts_internal, garbage_collect, _}) ->
   false;
+is_unsafe({erts_internal, map_next, 3}) ->
+  false;
 is_unsafe({Safe, _, _})
   when
     Safe =:= binary

--- a/tests/suites/erlang_tests/results/erlang_maps-maps_fold-inf-optimal.txt
+++ b/tests/suites/erlang_tests/results/erlang_maps-maps_fold-inf-optimal.txt
@@ -1,0 +1,47 @@
+Concuerror v0.19+build.2050.ref4b86cdf started at 20 Jun 2018 10:27:50
+ Options:
+  [{after_timeout,infinity},
+   {assertions_only,false},
+   {assume_racing,false},
+   {depth_bound,500},
+   {disable_sleep_sets,false},
+   {dpor,optimal},
+   {entry_point,{erlang_maps,maps_fold,[]}},
+   {exclude_module,[]},
+   {files,["/Users/stavros.aronis/git/Concuerror/tests/suites/erlang_tests/src/erlang_maps.erl"]},
+   {first_process_errors_only,false},
+   {ignore_error,[]},
+   {instant_delivery,true},
+   {interleaving_bound,infinity},
+   {keep_going,true},
+   {non_racing_system,[]},
+   {print_depth,20},
+   {quiet,true},
+   {scheduling,round_robin},
+   {scheduling_bound_type,none},
+   {show_races,false},
+   {strict_scheduling,false},
+   {symbolic_names,true},
+   {timeout,5000},
+   {treat_as_normal,[]},
+   {use_receive_patterns,true}]
+################################################################################
+Exploration completed!
+  No errors found!
+################################################################################
+Tips:
+--------------------------------------------------------------------------------
+* Check '--help attributes' for info on how to pass options via module attributes.
+* Running without a scheduling_bound corresponds to verification and may take a long time.
+
+################################################################################
+Info:
+--------------------------------------------------------------------------------
+* Writing results in /Users/stavros.aronis/git/Concuerror/tests/results/erlang_tests/results/erlang_maps-maps_fold-inf-optimal.txt
+* Automatically instrumented module io_lib
+* Showing PIDs as "<symbolic name(/last registered name)>" ('-h symbolic_names').
+* Instrumented & loaded module erlang_maps
+
+################################################################################
+Done at 20 Jun 2018 10:27:50 (Exit status: ok)
+  Summary: 0 errors, 1/1 interleavings explored

--- a/tests/suites/erlang_tests/src/erlang_maps.erl
+++ b/tests/suites/erlang_tests/src/erlang_maps.erl
@@ -1,0 +1,9 @@
+-module(erlang_maps).
+
+-compile(export_all).
+
+scenarios() ->
+  [ maps_fold ].
+
+maps_fold() ->
+  maps:fold(fun(_,_,Acc) -> Acc end, ok, #{}).


### PR DESCRIPTION
This is used by maps:fold/3 and others to walk through maps.

Fix for https://github.com/parapluu/Concuerror/issues/313

## Checklist

* [x] Has tests (or doesn't need them)
* [ ] Updates CHANGELOG (or too minor)
* [ ] References related Issues

Should it update the CHANGELOG?