### PR TITLE
Migrate from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,19 @@
+name: Website
+
+on:
+  push:
+    branches: master
+    paths: docs/**
+  pull_request:
+    branches: master
+    paths: docs/**
+
+jobs:
+  website-tests:
+    name: Run website tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: make -C docs test

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-updated: 2020-10-25
+updated: 2020-11-07
 description: "Homepage of the Concuerror, a tool for debugging, testing and verifying concurrent Erlang programs."
 ---
 


### PR DESCRIPTION
## Summary

Travis is changing its model and might be tricky to maintain. Let's try Github Actions.

## Checklist

* [ ] Has tests (or doesn't need them)
* [ ] Updates CHANGELOG (or too minor)
* [ ] References related Issues
