### PR TITLE
Pin container version 23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         target:
           - lint
           - dialyzer
-    container: erlang:latest
+    container: erlang:23.0
     name: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary

Pin the lint and dialyzer actions to latest actually supported version.

Fixes a problem with parapluu/Concuerror#330.

## Checklist

* [x] Has tests (or doesn't need them)
* [x] Updates CHANGELOG (or too minor)
* [x] References related Issues
