### PR TITLE
Fix persistent_term:get/1 builtin.

### DIFF
--- a/src/concuerror_callback.erl
+++ b/src/concuerror_callback.erl
@@ -1278,7 +1278,8 @@ run_built_in(persistent_term, Name, Arity, Args, Info) ->
     {erase, 1} ->
       run_built_in(ets, delete, 2, [?persistent_term|Args], Info);
     {get, 1} ->
-      run_built_in(ets, lookup_element, 3, [?persistent_term, 2|Args], Info);
+      [Key] = Args,
+      run_built_in(ets, lookup_element, 3, [?persistent_term, Key, 2], Info);
     {get, 2} ->
       [Key, Default] = Args,
       {R, NewInfo} =


### PR DESCRIPTION
## Summary

Prior to this fix the mock for that function would fail with `badarg` because it was translated to
`ets:lookup_element(?persistent_term, 2, Key)` instead of 
`ets:lookup_element(?persistent_term, Key, 2)`.

https://www.erlang.org/doc/apps/stdlib/ets.html#lookup_element/3

## Checklist

* [x] Has tests (or doesn't need them)
* [x] Updates CHANGELOG (or too minor)
* [ ] References related Issues
